### PR TITLE
Publish charm to 2.8/* track

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -7,12 +7,12 @@ on:
         type: choice
         description: 'Origin Channel'
         options:
-        - latest/edge
+        - 2.8/edge
       destination-channel:
         type: choice
         description: 'Destination Channel'
         options:
-        - latest/stable
+        - 2.8/stable
     secrets:
       CHARMHUB_TOKEN:
         required: true

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -5,7 +5,10 @@ on:
   push:
     branches:
       - main
-      # - 2.8/main
+      # workflow runs on main and 2.8/main are mutually exclusive.
+      # This will be replaced by 2.8/main once we finished moving the 
+      # legacy haproxy code to this repo.
+      # - 2.8/main 
 
 jobs:
   publish-to-edge:

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -5,10 +5,11 @@ on:
   push:
     branches:
       - main
+      # - 2.8/main
 
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
     with:
-      channel: latest/edge
+      channel: 2.8/edge


### PR DESCRIPTION
We are publishing the new haproxy charm to `2.8/{stable|edge}`. The reason for this is we have 2 versions of the haproxy charm co-existing at the same time. For now we've decided that the "legacy" charm which is at legacy/main will stay on latest/* and the new charm will be at 2.8/* for the moment since it provides haproxy v2.8. This PR updates the publish and promote target of relevant workflows.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
