### PR TITLE
update readme to specify location of the legacy haproxy charm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is the repository for the new haproxy charm supporting haproxy v2.8 and published in the [2.8/edge](https://charmhub.io/haproxy?channel=2.8/edge) channel. For the legacy charm in the [latest/edge](https://charmhub.io/haproxy?channel=2.8/edge) channel please refer to the [legacy/main](https://github.com/canonical/haproxy-operator/tree/legacy/main) branch.
+This is the repository for the new haproxy charm supporting haproxy v2.8 and published in the [2.8/edge](https://charmhub.io/haproxy?channel=2.8/edge) channel. For the legacy charm in the [latest/edge](https://charmhub.io/haproxy?channel=latest/edge) channel please refer to the [legacy/main](https://github.com/canonical/haproxy-operator/tree/legacy/main) branch.
 
 # Overview
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is the repository for the new haproxy charm supporting haproxy v2.8 and published in the [2.8/edge](https://charmhub.io/haproxy?channel=2.8/edge) channel. For the legacy charm in the [latest/edge](https://charmhub.io/haproxy?channel=2.8/edge) channel please refer to the [legacy/main](https://github.com/canonical/haproxy-operator/tree/legacy/main) branch.
+
 # Overview
 
 A Juju charm that deploys and manages haproxy on machine. HAProxy is a TCP/HTTP reverse proxy which is particularly suited for high availability environments. It features connection persistence through HTTP cookies, load balancing, header addition, modification, deletion both ways. It has request blocking capabilities and provides interface to display server status.


### PR DESCRIPTION
### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
