### PR TITLE
Run install logic in upgrade charm

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -92,6 +92,7 @@ class HAProxyCharm(ops.CharmBase):
 
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(self.on.get_certificate_action, self._on_get_certificate_action)
         self.framework.observe(
             self.on.certificates_relation_joined, self._on_certificates_relation_joined
@@ -132,6 +133,11 @@ class HAProxyCharm(ops.CharmBase):
         """Handle the config-changed event."""
         self._reconcile()
         self._reconcile_certificates()
+
+    def _on_upgrade_charm(self, _: typing.Any) -> None:
+        """Handle the upgrade-charm event."""
+        self.haproxy_service.install()
+        self.unit.status = ops.MaintenanceStatus("Waiting for haproxy to be configured.")
 
     @validate_config_and_tls(defer=True, block_on_tls_not_ready=True)
     def _on_certificates_relation_joined(self, _: RelationJoinedEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -244,7 +244,7 @@ class HAProxyCharm(ops.CharmBase):
                     config, ingress_requirers_information, tls_information.external_hostname
                 )
             case ProxyMode.LEGACY:
-                required_ports = set(
+                required_ports: set[Port] = set(
                     Port(protocol="tcp", port=service["service_port"])
                     for service in self.reverseproxy_requirer.get_services_definition().values()
                 )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,63 +111,94 @@ async def get_unit_address(application: Application) -> str:
 @pytest_asyncio.fixture(scope="module", name="any_charm_src")
 async def any_charm_src_fixture() -> dict[str, str]:
     """any-charm configuration to test with haproxy."""
-    return {
-        "any_charm.py": textwrap.dedent(
-            """
+    any_charm_py = textwrap.dedent(
+        """\
+        import pathlib
+        import ops
         from any_charm_base import AnyCharmBase
+        import apt
+        from subprocess import STDOUT, check_call
+        import os
         import textwrap
-        import logging
-        logger = logging.getLogger()
+        
+        nginx_config = textwrap.dedent(
+            \"\"\"
+                events {}
+                http {
+                    server {
+                        listen 8000;
+                        location /  {
+                            add_header Content-Type text/plain;
+                            return 200 'default server healthy';
+                        }
+                    }
+
+                    server {
+                        listen 8001;
+                        location /server1/health {
+                            add_header Content-Type text/plain;
+                            return 200 'server 1 healthy';
+                        }
+                    }
+                }
+            \"\"\"
+        )
         relation_data = textwrap.dedent(
             \"\"\"
                 - service_name: my_web_app
                   service_host: 0.0.0.0
-                  service_port: 80
+                  service_port: 8994
                   service_options:
                   - mode http
                   - timeout client 300000
                   - timeout server 300000
                   - balance leastconn
                   - option httpchk HEAD / HTTP/1.0
-                  - acl service_1 path_beg -i /service_1
-                  - use_backend extra_service_1 if service_1
-                  servers: [[server1, 10.0.1.1, 80, [check, rise 2, fall 5, maxconn 50]]]
+                  - acl server1 path_beg -i /server1/health
+                  - use_backend server1 if server1
+                  servers:
+                  - - default
+                    - %s
+                    - 8000
+                    - check
                   backends:
-                  - backend_name: extra_service_1
+                  - backend_name: server1
                     servers:
-                    - - extra_server_1
-                      - 10.0.1.1
-                      - 8000
-                      - &id001
-                        - check
-                        - inter 5000
-                        - rise 2
-                        - fall 5
-                        - maxconn 50
-                    - - extra_server_2
-                      - 10.0.1.2
+                    - - server1
+                      - %s
                       - 8001
-                      - *id001
+                      - check
             \"\"\"
         )
+
         class AnyCharm(AnyCharmBase):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
 
+            @property
+            def bind_address(self) -> str:
+                if bind := self.model.get_binding("juju-info"):
+                    return str(bind.network.bind_address)
+                return ""
+
             def update_relation_data(self):
                 relation = self.model.get_relation("provide-http")
+                bind_address = self.bind_address
                 relation.data[self.unit].update(
-                    {"services": relation_data, "hostname": "", "port": ""}
+                    {"services": relation_data % (bind_address, bind_address), "hostname": "", "port": ""}
                 )
-
-            def update_relation_data_single_service(self):
-                relation = self.model.get_relation("provide-http")
-                relation.data[self.unit].update(
-                    {"hostname": "10.0.0.0", "port": "80", "services": ""}
-                )
+                
+            def start_server(self):
+                check_call(['apt-get', 'install', '-y', 'nginx'], stdout=open(os.devnull,'wb'), stderr=STDOUT)
+                www_dir = pathlib.Path("/var/www/html")
+                pathlib.Path("/etc/nginx/nginx.conf").write_text(nginx_config, encoding="utf-8")
+                check_call(['nginx', '-T'], stdout=open(os.devnull,'wb'), stderr=STDOUT)
+                check_call(['systemctl', 'restart', 'nginx'], stdout=open(os.devnull,'wb'), stderr=STDOUT)
+                
+                self.unit.status = ops.ActiveStatus("server ready")
         """
-        ),
-    }
+    )
+    return {"any_charm.py": any_charm_py}
 
 
 @pytest_asyncio.fixture(scope="module", name="any_charm_ingress_requirer_name")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -120,7 +120,7 @@ async def any_charm_src_fixture() -> dict[str, str]:
         from subprocess import STDOUT, check_call
         import os
         import textwrap
-        
+
         nginx_config = textwrap.dedent(
             \"\"\"
                 events {}
@@ -185,16 +185,27 @@ async def any_charm_src_fixture() -> dict[str, str]:
                 relation = self.model.get_relation("provide-http")
                 bind_address = self.bind_address
                 relation.data[self.unit].update(
-                    {"services": relation_data % (bind_address, bind_address), "hostname": "", "port": ""}
+                    {
+                        "services": relation_data % (bind_address, bind_address),
+                        "hostname": "", "port": ""
+                    }
                 )
-                
+
             def start_server(self):
-                check_call(['apt-get', 'install', '-y', 'nginx'], stdout=open(os.devnull,'wb'), stderr=STDOUT)
+                check_call(
+                    ['apt-get', 'install', '-y', 'nginx'],
+                    stdout=open(os.devnull,'wb'),
+                    stderr=STDOUT
+                )
                 www_dir = pathlib.Path("/var/www/html")
                 pathlib.Path("/etc/nginx/nginx.conf").write_text(nginx_config, encoding="utf-8")
                 check_call(['nginx', '-T'], stdout=open(os.devnull,'wb'), stderr=STDOUT)
-                check_call(['systemctl', 'restart', 'nginx'], stdout=open(os.devnull,'wb'), stderr=STDOUT)
-                
+                check_call(
+                    ['systemctl', 'restart', 'nginx'],
+                    stdout=open(os.devnull,'wb'),
+                    stderr=STDOUT
+                )
+
                 self.unit.status = ops.ActiveStatus("server ready")
         """
     )


### PR DESCRIPTION
We should run any logic in `install` on `upgrade-charm` for a machine charm.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
