### PR TITLE
Remove modules from integration test workflow

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,4 +12,3 @@ jobs:
       juju-channel: 3.3/stable
       self-hosted-runner: true
       charmcraft-channel: latest/edge
-      modules: '["test_action.py", "test_config.py", "test_charm.py", "test_http_interface.py", "test_cos.py"]'


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Run all integration tests.

### Rationale

Enable all integration tests.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
