### PR TITLE
add support for strip_prefix

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,4 +12,4 @@ jobs:
       juju-channel: 3.3/stable
       self-hosted-runner: true
       charmcraft-channel: latest/edge
-      modules: '["test_action.py", "test_config.py", "test_charm.py", "test_http_interface.py", "test_cos.py"]'
+      modules: '["test_action.py", "test_config.py", "test_charm.py", "test_http_interface.py", "test_cos.py", "test_ingress.py"]'

--- a/templates/haproxy_ingress.cfg.j2
+++ b/templates/haproxy_ingress.cfg.j2
@@ -19,6 +19,9 @@ frontend ingress
 {% for backend in ingress_requirers_information.backends %}
 backend {{ backend.backend_name }}
     balance roundrobin
+{% if backend.strip_prefix %}
+    http-request set-path %[path,regsub(^/{{ backend.backend_name }},/,)]
+{% endif %}
 {% for server in backend.servers %}
     server {{ server.server_name }} {{ server.hostname_or_ip }}:{{ server.port }} check
 {% endfor %}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -177,18 +177,15 @@ async def any_charm_ingress_requirer_name_fixture() -> str:
 
 
 @pytest_asyncio.fixture(scope="module", name="any_charm_src_ingress_requirer")
-async def any_charm_src_ingress_requirer_fixture(
-    model: Model, any_charm_ingress_requirer_name: str
-) -> dict[str, str]:
+async def any_charm_src_ingress_requirer_fixture() -> dict[str, str]:
     """
     assert: None
     action: Build and deploy nginx-ingress-integrator charm, also deploy and relate an any-charm
         application with ingress relation for test purposes.
     assert: HTTP request should be forwarded to the application.
     """
-    ingress_path_prefix = f"{model.name}-{any_charm_ingress_requirer_name}"
     any_charm_py = textwrap.dedent(
-        f"""\
+        """\
     import pathlib
     import subprocess
     import ops
@@ -199,13 +196,13 @@ async def any_charm_src_ingress_requirer_fixture(
     class AnyCharm(AnyCharmBase):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.ingress = IngressPerAppRequirer(self, port=80)
+            self.ingress = IngressPerAppRequirer(self, port=80, strip_prefix=True)
 
         def start_server(self):
             apt.update()
             apt.add_package(package_names="apache2")
             www_dir = pathlib.Path("/var/www/html")
-            file_path = www_dir / "{ingress_path_prefix}" / "ok"
+            file_path = www_dir / "ok"
             file_path.parent.mkdir(exist_ok=True)
             file_path.write_text("ok!")
             self.unit.status = ops.ActiveStatus("Server ready")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -83,7 +83,7 @@ async def configured_application_with_tls_fixture(
     return application
 
 
-async def get_unit_address(application: Application) -> str:
+async def get_unit_ip_address(application: Application) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
     """Get the unit address to make HTTP requests.
 
     Args:
@@ -101,7 +101,19 @@ async def get_unit_address(application: Application) -> str:
         else unit_status.public_address.decode()
     )
 
-    unit_ip_address = ipaddress.ip_address(address)
+    return ipaddress.ip_address(address)
+
+
+async def get_unit_address(application: Application) -> str:
+    """Get the unit address to make HTTP requests.
+
+    Args:
+        application: The deployed application
+
+    Returns:
+        The unit address
+    """
+    unit_ip_address = await get_unit_ip_address(application)
     url = f"http://{str(unit_ip_address)}"
     if isinstance(unit_ip_address, ipaddress.IPv6Address):
         url = f"http://[{str(unit_ip_address)}]"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -83,7 +83,9 @@ async def configured_application_with_tls_fixture(
     return application
 
 
-async def get_unit_ip_address(application: Application) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+async def get_unit_ip_address(
+    application: Application,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
     """Get the unit address to make HTTP requests.
 
     Args:

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -1,0 +1,92 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper methods for integration tests."""
+
+import json
+from urllib.parse import ParseResult, urlparse
+
+from juju.application import Application
+from pytest_operator.plugin import OpsTest
+from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES, HTTPAdapter
+
+
+class DNSResolverHTTPSAdapter(HTTPAdapter):
+    """A simple mounted DNS resolver for HTTP requests."""
+
+    def __init__(
+        self,
+        hostname,
+        ip,
+    ):
+        """Initialize the dns resolver.
+
+        Args:
+            hostname: DNS entry to resolve.
+            ip: Target IP address.
+        """
+        self.hostname = hostname
+        self.ip = ip
+        super().__init__(
+            pool_connections=DEFAULT_POOLSIZE,
+            pool_maxsize=DEFAULT_POOLSIZE,
+            max_retries=DEFAULT_RETRIES,
+            pool_block=DEFAULT_POOLBLOCK,
+        )
+
+    # Ignore pylint rule as this is the parent method signature
+    def send(
+        self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None
+    ):  # pylint: disable=too-many-arguments, too-many-positional-arguments
+        """Wrap HTTPAdapter send to modify the outbound request.
+
+        Args:
+            request: Outbound HTTP request.
+            stream: argument used by parent method.
+            timeout: argument used by parent method.
+            verify: argument used by parent method.
+            cert: argument used by parent method.
+            proxies: argument used by parent method.
+
+        Returns:
+            Response: HTTP response after modification.
+        """
+        connection_pool_kwargs = self.poolmanager.connection_pool_kw
+
+        result = urlparse(request.url)
+        if result.hostname == self.hostname:
+            ip = self.ip
+            if result.scheme == "https" and ip:
+                request.url = request.url.replace(
+                    "https://" + result.hostname,
+                    "https://" + ip,
+                )
+                connection_pool_kwargs["server_hostname"] = result.hostname
+                connection_pool_kwargs["assert_hostname"] = result.hostname
+                request.headers["Host"] = result.hostname
+            else:
+                connection_pool_kwargs.pop("server_hostname", None)
+                connection_pool_kwargs.pop("assert_hostname", None)
+
+        return super().send(request, stream, timeout, verify, cert, proxies)
+
+
+async def get_ingress_url_for_application(
+    ingress_requirer_application: Application, ops_test: OpsTest
+) -> ParseResult:
+    """Get the ingress url from the requirer's unit data.
+
+    Args:
+        ingress_requirer_application: Requirer application.
+        ops_test: OpsTest framework to run juju show-unit.
+
+    Returns:
+        ParseResult: The parsed ingress url.
+    """
+    unit_name = ingress_requirer_application.units[0].name
+    _, stdout, _ = await ops_test.juju("show-unit", unit_name, "--format", "json")
+    unit_information = json.loads(stdout)[unit_name]
+    ingress_integration_data = json.loads(
+        unit_information["relation-info"][0]["application-data"]["ingress"]
+    )
+    return urlparse(ingress_integration_data["url"])

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -46,7 +46,7 @@ async def test_ingress_integration(
     session.mount("https://", DNSResolverHTTPSAdapter(ingress_url.netloc, unit_address))
 
     response = session.get(
-        f"http://{unit_address}{ingress_url.path}",
+        f"{unit_address}{ingress_url.path}",
         headers={"Host": ingress_url.netloc},
         verify=False,  # nosec - calling charm ingress URL
         allow_redirects=False,
@@ -56,7 +56,7 @@ async def test_ingress_integration(
     assert response.headers["location"] == f"https://{ingress_url.netloc}:443{ingress_url.path}"
 
     response = session.get(
-        f"http://{unit_address}{ingress_url.path}/ok",
+        f"{unit_address}{ingress_url.path}/ok",
         headers={"Host": ingress_url.netloc},
         verify=False,  # nosec - calling charm ingress URL
         timeout=30,

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -53,7 +53,7 @@ async def test_ingress_integration(
         timeout=30,
     )
     assert response.status_code == 302
-    assert response.headers["location"] == f"https://{ingress_url.netloc}:443{ingress_url.path}"
+    assert response.headers["location"] == f"https://{ingress_url.netloc}{ingress_url.path}"
 
     response = session.get(
         f"{unit_address}{ingress_url.path}/ok",

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -52,7 +52,7 @@ async def test_ingress_integration(
         allow_redirects=False,
         timeout=30,
     )
-    assert response.status_code == 301
+    assert response.status_code == 302
     assert response.headers["location"] == f"https://{ingress_url.netloc}:443{ingress_url.path}"
 
     response = session.get(

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -33,8 +33,7 @@ async def test_ingress_integration(
         idle_period=30,
         status="active",
     )
-    path = f"{any_charm_ingress_requirer.model.name}-{any_charm_ingress_requirer.name}/ok"
-    response = requests.get(f"{unit_address}/{path}", timeout=5)
+    response = requests.get(f"{unit_address}/ok", timeout=5)
 
     assert response.status_code == 200
     assert "ok!" in response.text

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -40,7 +40,7 @@ async def test_ingress_integration(
 
     ingress_url = await get_ingress_url_for_application(any_charm_ingress_requirer, ops_test)
     assert ingress_url.netloc == TEST_EXTERNAL_HOSTNAME_CONFIG
-    assert ingress_url.path == f"/{application.model.name}-{any_charm_ingress_requirer.name}"
+    assert ingress_url.path == f"/{application.model.name}-{any_charm_ingress_requirer.name}/"
 
     session = Session()
     session.mount("https://", DNSResolverHTTPSAdapter(ingress_url.netloc, unit_address))

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -56,7 +56,7 @@ async def test_ingress_integration(
     assert response.headers["location"] == f"https://{ingress_url.netloc}{ingress_url.path}"
 
     response = session.get(
-        f"{unit_address}{ingress_url.path}/ok",
+        f"{unit_address}{ingress_url.path}ok",
         headers={"Host": ingress_url.netloc},
         verify=False,  # nosec - calling charm ingress URL
         timeout=30,


### PR DESCRIPTION
Parse  `strip_prefix` in ingress requirer app databag and add the corresponding `http_request` to the backend.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
