### PR TITLE
Replace how prefix is removed

### DIFF
--- a/templates/haproxy_ingress.cfg.j2
+++ b/templates/haproxy_ingress.cfg.j2
@@ -20,7 +20,7 @@ frontend ingress
 backend {{ backend.backend_name }}
     balance roundrobin
 {% if backend.strip_prefix %}
-    http-request set-path %[path,regsub(^/{{ backend.backend_name }},/,)]
+    http-request replace-path /{{ backend.backend_name }}(/)?(.*) /\2
 {% endif %}
 {% for server in backend.servers %}
     server {{ server.server_name }} {{ server.hostname_or_ip }}:{{ server.port }} check


### PR DESCRIPTION
Applicable spec: <link>

### Overview

During IRC Bridge integration test, I noticed this behavior:

```
$ curl https://haproxy.internal/test-ingress-q3xx-irc-bridge/health -k
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET //health</pre>
</body>
</html>
```

So this PR changes how the prefix is replaced and forwarded to the backend application by replacing the request path starting with /<model-name>-<application name> (optionally followed by a slash) with the remainder of the path (\2),

### Rationale

Fix strip prefix

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
