### PR TITLE
add docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+haproxy-operator is an open-source software operator that deploys and operates Haproxy IAAS/VM that functions on Juju 3.3 and above.
+
+The haproxy-operator offers advanced features such as TLS, monitoring and high-availability.
+
+> This operator is built for **IAAS/VM** and is not supported in **Kubernetes** environments


### PR DESCRIPTION
Fixes #55 

This PR adds the index page of the charm's documentation

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
