### PR TITLE
Improvements to handling certs, update template to handle ipv6

### DIFF
--- a/src/state/validation.py
+++ b/src/state/validation.py
@@ -20,7 +20,7 @@ C = typing.TypeVar("C", bound=ops.CharmBase)
 # We ignore flake8 complexity warning here because
 # the decorator is complex by design as it needs to catch all exceptions
 def validate_config_and_tls(  # noqa: C901
-    defer: bool = False, block_on_tls_not_ready: bool = False
+    defer: bool = False,
 ) -> typing.Callable[
     [typing.Callable[[C, typing.Any], None]], typing.Callable[[C, typing.Any], None]
 ]:
@@ -28,7 +28,6 @@ def validate_config_and_tls(  # noqa: C901
 
     Args:
         defer: whether to defer the event.
-        block_on_tls_not_ready: Whether to block the charm if TLS is not ready.
 
     Returns:
         the function decorator.
@@ -71,8 +70,7 @@ def validate_config_and_tls(  # noqa: C901
                 if defer:
                     event, *_ = args
                     event.defer()
-                if block_on_tls_not_ready:
-                    instance.unit.status = ops.BlockedStatus(str(exc))
+                instance.unit.status = ops.BlockedStatus(str(exc))
                 logger.exception("Not ready to handle TLS.")
                 return None
             except PrivateKeyNotGeneratedError as exc:

--- a/templates/haproxy_ingress.cfg.j2
+++ b/templates/haproxy_ingress.cfg.j2
@@ -2,8 +2,8 @@
 {% block proxy_configuration %}
 frontend ingress
     mode http
-    bind :80
-    bind :443 ssl crt {{ haproxy_crt_dir }}
+    bind [::]:80 v4v6
+    bind [::]:443 v4v6 ssl crt {{ haproxy_crt_dir }}
 
     # Redirect HTTP to HTTPS
     http-request redirect scheme https unless { ssl_fc }


### PR DESCRIPTION
Update the exception handling logic and removed the unnecessary `block_on_tls_not_ready` parameter as we always want to block on tls-related events if tls is not ready to be handled.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
