### PR TITLE
add compression by default for ingress

### DIFF
--- a/templates/haproxy_ingress.cfg.j2
+++ b/templates/haproxy_ingress.cfg.j2
@@ -5,6 +5,11 @@ frontend ingress
     bind [::]:80 v4v6
     bind [::]:443 v4v6 ssl crt {{ haproxy_crt_dir }}
 
+    filter compression
+    compression algo gzip
+    compression type text/css text/html text/javascript application/javascript text/plain text/xml application/json
+    compression offload
+
     # Redirect HTTP to HTTPS
     http-request redirect scheme https unless { ssl_fc }
 


### PR DESCRIPTION
Add compression by default for the ingress relation for html, css, js, plain, json and XML

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
