### PR TITLE
add missing print output to artifact script

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -28,7 +28,7 @@ jobs:
           import os
 
           workspace = os.environ["GITHUB_WORKSPACE"]
-          json.dumps(
+          print(json.dumps(
             {
               "any_charm.py": pathlib.Path(f"{workspace}/tests/integration/haproxy_route_requirer.py").read_text(
                 encoding="utf-8"
@@ -38,7 +38,7 @@ jobs:
               ),
               "apt.py": pathlib.Path(f"{workspace}/lib/charms/operator_libs_linux/v0/apt.py").read_text(encoding="utf-8"),
             }
-          )
+          ))
           EOF
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The script to generate the haproxy-route-requirer-src json was missing a `print()` statement to write it to the artifact file, this PR simply adds it.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
