### PR TITLE
ISD-2946 add docs for high-availability configurations

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -38,7 +38,7 @@ description: |
   VMs and bare metal.
 summary: Fast and reliable load balancing reverse proxy.
 links:
-  documentation: https://discourse.charmhub.io/
+  documentation: https://discourse.charmhub.io/t/haproxy-documentation-overview/17216
   issues: https://github.com/canonical/haproxy-operator/issues
   source: https://github.com/canonical/haproxy-operator
   contact:

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -1,5 +1,5 @@
 # High availability
-High availability (HA) is a characteristic of a system that aims to ensure an agreed level of operational performance, usually uptime, for a higher than normal period. In this document we will discuss different possible configurations for High availability supported by the `hacluster` subordinate charm.
+High availability (HA) is a characteristic of a system that aims to ensure an agreed level of operational performance, usually uptime, for a higher than normal period. In this document we will discuss different possible configurations for high availability supported by the `hacluster` subordinate charm.
 
 # Active/active
 An active-active configuration consists of two or more HAProxy units that reply to incoming requests at the same time. Increasing the number of haproxy charm units can be done either during deployment with the `-n` flag or by using the `juju add-unit` command: 

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -1,0 +1,40 @@
+# High availability
+High availability (HA) is a characteristic of a system that aims to ensure an agreed level of operational performance, usually uptime, for a higher than normal period. In this document we will discuss different possible configurations for High availability supported by the `hacluster` subordinate charm.
+
+# Active/active
+An active-active configuration consists of two or more Haproxy units that reply to incoming requests at the same time. Increasing the number of haproxy charm units can be done either during deployment with the `-n` flag or by using the `juju add-unit` command: 
+```
+juju add-unit haproxy -n 2
+```
+
+To configure a single entrypoint for all haproxy units, we can employ a variety of methods, which includes but not limited to:
+* Using a floating IP address
+* DNS round-robin
+* Using a load balancer
+
+Note: Configuration of the entrypoint for the active-active configuration is outside of the scope of responsibility for the haproxy charm.
+
+## DNS round-robin
+DNS round-robin provides a single entrypoint for all haproxy units with no overhead, shifting the responsibility to the DNS server for load balancing purposes. However,  most DNS solutions lack health checks of unhealthy hosts, as well as requiring configuration changes every time there’s a change in the number of haproxy units or their IP addresses.
+
+## Load balancing
+Most of the time a load balancer will be configured with a health check monitor and a floating IP to ensure availability of backend hosts as well as retain control of the assigned external IP address. Here is an example using Octavia: https://docs.openstack.org/octavia/stein/user/guides/basic-cookbook.html#basic-lb-with-hm-and-fip
+
+
+# Active/passive
+An active-passive configuration consists of two or more nodes. In this configuration, only one unit is considered "active" at any given time. All other units are considered "passive" and they don't reply to incoming requests. The single entrypoint for all haproxy units exists in the form of a virtual IP address. The `hacluster` subordinate charm is responsible for managing this virtual IP address, attaching it to the "active" Haproxy unit and moving it to a "passive" unit when the "active" unit goes down.
+
+By default it is required to have at least 3 Haproxy units when using the `hacluster` subordinate charm to maintain a quorum. However, this can be configured. See the section on [Active/passive cluster configuration](##active/passive-cluster-configuration) for more details.
+
+## Active/passive cluster configuration
+The `hacluster` charm provide operators with configuration options to fine-tune the cluster's behavior. Below are some key settings for Haproxy:
+
+### [cluster_count](https://opendev.org/openstack/charm-hacluster/src/commit/2449932bf7c618fda4fa412228a133688db13b02/config.yaml#L125)
+Number of peer units required to bootstrap cluster services.
+
+### [no_quorum_policy](https://opendev.org/openstack/charm-hacluster/src/commit/2449932bf7c618fda4fa412228a133688db13b02/config.yaml#L221)
+What to do when the cluster does not have quorum. Allowed values are:
+* ignore: continue all resource management,
+* freeze: continue resource management, but don’t recover resources from nodes not in the affected partition,
+* stop: stop all resources in the affected cluster partition,
+* suicide: fence all nodes in the affected cluster partition

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -7,7 +7,7 @@ An active-active configuration consists of two or more Haproxy units that reply 
 juju add-unit haproxy -n 2
 ```
 
-To configure a single entrypoint for all haproxy units, we can employ a variety of methods, which includes but not limited to:
+To configure a single entrypoint for all haproxy charm units, we can employ a variety of methods, which includes but not limited to:
 * Using a floating IP address
 * DNS round-robin
 * Using a load balancer

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -12,15 +12,15 @@ To configure a single entrypoint for all haproxy charm units, we can employ a va
 * DNS round-robin
 * Using a load balancer
 
-[note]
-Configuration of the entrypoint for the active-active configuration is outside of the scope of responsibility for the haproxy charm.
-[/note]
+> **_NOTE:_**: Configuration of the entrypoint for the active-active configuration is outside of the scope of responsibility for the haproxy charm.
 
 ## DNS round-robin
 DNS round-robin provides a single entrypoint for all haproxy charm units with no overhead, shifting the responsibility to the DNS server for load balancing purposes. However, most DNS solutions lack health checks of unhealthy hosts, as well as requiring configuration changes every time there’s a change in the number of haproxy charm units or their IP addresses.
 
 ## Load balancing
 Most of the time a load balancer will be configured with a health check monitor and a floating IP to ensure availability of backend hosts as well as retain control of the assigned external IP address. For an example using Octavia, see the [OpenStack documentation](https://docs.openstack.org/octavia/stein/user/guides/basic-cookbook.html#basic-lb-with-hm-and-fip).
+
+> **_NOTE:_**: Sticky session should be configured explicitly at the load balancer level.
 
 
 # Active/passive

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -24,7 +24,7 @@ Most of the time a load balancer will be configured with a health check monitor 
 # Active/passive
 An active-passive configuration consists of two or more nodes. In this configuration, only one unit is considered "active" at any given time. All other units are considered "passive" meaning they don't reply to incoming requests. The single entrypoint for all haproxy charm units exists in the form of a virtual IP address. The `hacluster` subordinate charm is responsible for managing this virtual IP address, attaching it to the "active" HAProxy unit and moving it to a "passive" unit when the "active" unit goes down.
 
-By default it is required to have at least 3 Haproxy units when using the `hacluster` subordinate charm to maintain a quorum. However, this can be configured. See the section on [Active/passive cluster configuration](##active/passive-cluster-configuration) for more details.
+By default it is required to have at least 3 HAProxy units when using the `hacluster` subordinate charm to maintain a quorum. However, this number can be configured. See the next section on active/passive cluster configuration for more details.
 
 ## Active/passive cluster configuration
 The `hacluster` charm provide operators with configuration options to fine-tune the cluster's behavior. Below are some key settings for Haproxy:

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -22,7 +22,7 @@ Most of the time a load balancer will be configured with a health check monitor 
 
 
 # Active/passive
-An active-passive configuration consists of two or more nodes. In this configuration, only one unit is considered "active" at any given time. All other units are considered "passive" and they don't reply to incoming requests. The single entrypoint for all haproxy units exists in the form of a virtual IP address. The `hacluster` subordinate charm is responsible for managing this virtual IP address, attaching it to the "active" Haproxy unit and moving it to a "passive" unit when the "active" unit goes down.
+An active-passive configuration consists of two or more nodes. In this configuration, only one unit is considered "active" at any given time. All other units are considered "passive" meaning they don't reply to incoming requests. The single entrypoint for all haproxy charm units exists in the form of a virtual IP address. The `hacluster` subordinate charm is responsible for managing this virtual IP address, attaching it to the "active" HAProxy unit and moving it to a "passive" unit when the "active" unit goes down.
 
 By default it is required to have at least 3 Haproxy units when using the `hacluster` subordinate charm to maintain a quorum. However, this can be configured. See the section on [Active/passive cluster configuration](##active/passive-cluster-configuration) for more details.
 

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -2,7 +2,7 @@
 High availability (HA) is a characteristic of a system that aims to ensure an agreed level of operational performance, usually uptime, for a higher than normal period. In this document we will discuss different possible configurations for High availability supported by the `hacluster` subordinate charm.
 
 # Active/active
-An active-active configuration consists of two or more Haproxy units that reply to incoming requests at the same time. Increasing the number of haproxy charm units can be done either during deployment with the `-n` flag or by using the `juju add-unit` command: 
+An active-active configuration consists of two or more HAProxy units that reply to incoming requests at the same time. Increasing the number of haproxy charm units can be done either during deployment with the `-n` flag or by using the `juju add-unit` command: 
 ```
 juju add-unit haproxy -n 2
 ```

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -17,7 +17,7 @@ Configuration of the entrypoint for the active-active configuration is outside o
 [/note]
 
 ## DNS round-robin
-DNS round-robin provides a single entrypoint for all haproxy units with no overhead, shifting the responsibility to the DNS server for load balancing purposes. However,  most DNS solutions lack health checks of unhealthy hosts, as well as requiring configuration changes every time there’s a change in the number of haproxy units or their IP addresses.
+DNS round-robin provides a single entrypoint for all haproxy charm units with no overhead, shifting the responsibility to the DNS server for load balancing purposes. However, most DNS solutions lack health checks of unhealthy hosts, as well as requiring configuration changes every time there’s a change in the number of haproxy charm units or their IP addresses.
 
 ## Load balancing
 Most of the time a load balancer will be configured with a health check monitor and a floating IP to ensure availability of backend hosts as well as retain control of the assigned external IP address. For an example using Octavia, see the [OpenStack documentation](https://docs.openstack.org/octavia/stein/user/guides/basic-cookbook.html#basic-lb-with-hm-and-fip).

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -34,7 +34,7 @@ Number of peer units required to bootstrap cluster services.
 
 ### [no_quorum_policy](https://opendev.org/openstack/charm-hacluster/src/commit/2449932bf7c618fda4fa412228a133688db13b02/config.yaml#L221)
 What to do when the cluster does not have quorum. Allowed values are:
-* ignore: continue all resource management,
-* freeze: continue resource management, but don’t recover resources from nodes not in the affected partition,
-* stop: stop all resources in the affected cluster partition,
-* suicide: fence all nodes in the affected cluster partition
+* ignore: continue all resource management.
+* freeze: continue resource management, but don’t recover resources from nodes not in the affected partition.
+* stop: stop all resources in the affected cluster partition.
+* suicide: fence all nodes in the affected cluster partition.

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -18,7 +18,7 @@ Note: Configuration of the entrypoint for the active-active configuration is out
 DNS round-robin provides a single entrypoint for all haproxy units with no overhead, shifting the responsibility to the DNS server for load balancing purposes. However,  most DNS solutions lack health checks of unhealthy hosts, as well as requiring configuration changes every time there’s a change in the number of haproxy units or their IP addresses.
 
 ## Load balancing
-Most of the time a load balancer will be configured with a health check monitor and a floating IP to ensure availability of backend hosts as well as retain control of the assigned external IP address. Here is an example using Octavia: https://docs.openstack.org/octavia/stein/user/guides/basic-cookbook.html#basic-lb-with-hm-and-fip
+Most of the time a load balancer will be configured with a health check monitor and a floating IP to ensure availability of backend hosts as well as retain control of the assigned external IP address. For an example using Octavia, see the [OpenStack documentation](https://docs.openstack.org/octavia/stein/user/guides/basic-cookbook.html#basic-lb-with-hm-and-fip).
 
 
 # Active/passive

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -27,7 +27,7 @@ An active-passive configuration consists of two or more nodes. In this configura
 By default it is required to have at least 3 HAProxy units when using the `hacluster` subordinate charm to maintain a quorum. However, this number can be configured. See the next section on active/passive cluster configuration for more details.
 
 ## Active/passive cluster configuration
-The `hacluster` charm provide operators with configuration options to fine-tune the cluster's behavior. Below are some key settings for Haproxy:
+The `hacluster` charm provide operators with configuration options to fine-tune the cluster's behavior. Below are some key settings for HAProxy.
 
 ### [cluster_count](https://opendev.org/openstack/charm-hacluster/src/commit/2449932bf7c618fda4fa412228a133688db13b02/config.yaml#L125)
 Number of peer units required to bootstrap cluster services.

--- a/docs/explanation/high-availability.md
+++ b/docs/explanation/high-availability.md
@@ -12,7 +12,9 @@ To configure a single entrypoint for all haproxy charm units, we can employ a va
 * DNS round-robin
 * Using a load balancer
 
-Note: Configuration of the entrypoint for the active-active configuration is outside of the scope of responsibility for the haproxy charm.
+[note]
+Configuration of the entrypoint for the active-active configuration is outside of the scope of responsibility for the haproxy charm.
+[/note]
 
 ## DNS round-robin
 DNS round-robin provides a single entrypoint for all haproxy units with no overhead, shifting the responsibility to the DNS server for load balancing purposes. However,  most DNS solutions lack health checks of unhealthy hosts, as well as requiring configuration changes every time there’s a change in the number of haproxy units or their IP addresses.


### PR DESCRIPTION
Add docs explaining different HA configurations for Haproxy:
* active-active
  * dns round-robin
  * load balancing
* active-passive with details on cluster configurations

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
