### PR TITLE
Fix linting dependecies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps =
     pytest-asyncio
     pytest-operator
     requests
+    snowballstemmer<3.0.0
     types-PyYAML
     types-requests
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
The linting step is broken by new release https://pypi.org/project/snowballstemmer/3.0.0/

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
