### PR TITLE
Temporary disable sendhdr for httpchk

### DIFF
--- a/lib/charms/haproxy/v0/haproxy_route.py
+++ b/lib/charms/haproxy/v0/haproxy_route.py
@@ -142,7 +142,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"

--- a/templates/haproxy_route.cfg.j2
+++ b/templates/haproxy_route.cfg.j2
@@ -38,7 +38,10 @@ backend {{ backend.backend_name }}
     timeout queue {{ backend.application_data.timeout.queue }}
 
     option httpchk {% if backend.application_data.check.path %}GET {{ backend.application_data.check.path }}{% endif %}
-
+    # Some application ( like pollen ) doesn't care about the generated ingress URL and thus does not expect healthcheck requests to come with a header.
+    # In those cases haproxy will refuse to proxy incoming requests and replied with 503.
+    # Until we find a more suitable solution we won't send host headers in httpchk.
+    # http-check send hdr Host {{ backend.hostname_acls[0] }}
 {% if backend.application_data.rate_limit %}
     http-request track-sc0 src table  haproxy_peers/{{ backend.backend_name }}_rate_limit
     http-request {{ backend.application_data.rate_limit.policy.value }} if { sc_http_req_rate(0,haproxy_peers/{{ backend.backend_name }}_rate_limit) gt {{ backend.application_data.rate_limit.connections_per_minute }} }

--- a/templates/haproxy_route.cfg.j2
+++ b/templates/haproxy_route.cfg.j2
@@ -39,8 +39,6 @@ backend {{ backend.backend_name }}
 
     option httpchk {% if backend.application_data.check.path %}GET {{ backend.application_data.check.path }}{% endif %}
 
-    http-check send hdr Host {{ backend.hostname_acls[0] }}
-
 {% if backend.application_data.rate_limit %}
     http-request track-sc0 src table  haproxy_peers/{{ backend.backend_name }}_rate_limit
     http-request {{ backend.application_data.rate_limit.policy.value }} if { sc_http_req_rate(0,haproxy_peers/{{ backend.backend_name }}_rate_limit) gt {{ backend.application_data.rate_limit.connections_per_minute }} }


### PR DESCRIPTION
Some application ( like pollen ) doesn't care about the generated ingress URL and thus does not expect healthcheck requests to come with a header. In those cases haproxy will refuse to proxy incoming requests and replied with 503.

Until we find a more suitable solution i suggest we disable sending host headers in httpchk.

This PR also update the libpatch version to properly align with charmhub

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
