### PR TITLE
add check_port to configure port for http-check

### DIFF
--- a/lib/charms/haproxy/v0/haproxy_route.py
+++ b/lib/charms/haproxy/v0/haproxy_route.py
@@ -142,7 +142,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
@@ -270,6 +270,7 @@ class ServerHealthCheck(BaseModel):
         rise: Number of consecutive successful health checks required for up.
         fall: Number of consecutive failed health checks required for DOWN.
         path: List of URL paths to use for HTTP health checks.
+        port: Customize port value for http-check.
     """
 
     interval: int = Field(
@@ -282,6 +283,7 @@ class ServerHealthCheck(BaseModel):
         description="How many failed health checks before server is considered down.", default=3
     )
     path: Optional[str] = Field(description="The health check path.", default=None)
+    port: Optional[int] = Field(description="The health check port.", default=None)
 
 
 # tarpit is not yet implemented
@@ -807,6 +809,7 @@ class HaproxyRouteRequirer(Object):
         check_rise: Optional[int] = None,
         check_fall: Optional[int] = None,
         check_path: Optional[str] = None,
+        check_port: Optional[int] = None,
         path_rewrite_expressions: Optional[list[str]] = None,
         query_rewrite_expressions: Optional[list[str]] = None,
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
@@ -839,6 +842,7 @@ class HaproxyRouteRequirer(Object):
             check_rise: Number of successful health checks before server is considered up.
             check_fall: Number of failed health checks before server is considered down.
             check_path: The path to use for server health checks.
+            check_port: The port to use for http-check.
             path_rewrite_expressions: List of regex expressions for path rewrites.
             query_rewrite_expressions: List of regex expressions for query rewrites.
             header_rewrite_expressions: List of tuples containing header name
@@ -876,6 +880,7 @@ class HaproxyRouteRequirer(Object):
             check_rise,
             check_fall,
             check_path,
+            check_port,
             path_rewrite_expressions,
             query_rewrite_expressions,
             header_rewrite_expressions,
@@ -926,6 +931,7 @@ class HaproxyRouteRequirer(Object):
         check_rise: Optional[int] = None,
         check_fall: Optional[int] = None,
         check_path: Optional[str] = None,
+        check_port: Optional[int] = None,
         path_rewrite_expressions: Optional[list[str]] = None,
         query_rewrite_expressions: Optional[list[str]] = None,
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
@@ -955,6 +961,7 @@ class HaproxyRouteRequirer(Object):
             check_rise: Number of successful health checks before server is considered up.
             check_fall: Number of failed health checks before server is considered down.
             check_path: The path to use for server health checks.
+            check_port: The port to use for http-check.
             path_rewrite_expressions: List of regex expressions for path rewrites.
             query_rewrite_expressions: List of regex expressions for query rewrites.
             header_rewrite_expressions: List of tuples containing header name
@@ -983,6 +990,7 @@ class HaproxyRouteRequirer(Object):
             check_rise,
             check_fall,
             check_path,
+            check_port,
             path_rewrite_expressions,
             query_rewrite_expressions,
             header_rewrite_expressions,
@@ -1014,6 +1022,7 @@ class HaproxyRouteRequirer(Object):
         check_rise: Optional[int] = None,
         check_fall: Optional[int] = None,
         check_path: Optional[str] = None,
+        check_port: Optional[int] = None,
         path_rewrite_expressions: Optional[list[str]] = None,
         query_rewrite_expressions: Optional[list[str]] = None,
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
@@ -1043,6 +1052,7 @@ class HaproxyRouteRequirer(Object):
             check_rise: Number of successful health checks before server is considered up.
             check_fall: Number of failed health checks before server is considered down.
             check_path: The path to use for server health checks.
+            check_port: The port to use for http-check.
             path_rewrite_expressions: List of regex expressions for path rewrites.
             query_rewrite_expressions: List of regex expressions for query rewrites.
             header_rewrite_expressions: List of tuples containing header name and
@@ -1109,7 +1119,7 @@ class HaproxyRouteRequirer(Object):
         }
 
         if check := self._generate_server_healthcheck_configuration(
-            check_interval, check_rise, check_fall, check_path
+            check_interval, check_rise, check_fall, check_path, check_port
         ):
             application_data["check"] = check
 
@@ -1130,6 +1140,7 @@ class HaproxyRouteRequirer(Object):
         rise: Optional[int],
         fall: Optional[int],
         path: Optional[str],
+        port: Optional[int],
     ) -> dict[str, int | Optional[str]]:
         """Generate configuration for server health checks.
 
@@ -1137,7 +1148,8 @@ class HaproxyRouteRequirer(Object):
             interval: Time between health checks in seconds.
             rise: Number of successful checks before marking server as up.
             fall: Number of failed checks before marking server as down.
-            path: the path to use for health checks.
+            path: The path to use for health checks.
+            port: The port to use for http-check.
 
         Returns:
             dict[str, int | Optional[str]]: Health check configuration dictionary.
@@ -1149,6 +1161,7 @@ class HaproxyRouteRequirer(Object):
                 "rise": rise,
                 "fall": fall,
                 "path": path,
+                "port": port,
             }
         return server_healthcheck_configuration
 

--- a/templates/haproxy_route.cfg.j2
+++ b/templates/haproxy_route.cfg.j2
@@ -37,11 +37,11 @@ backend {{ backend.backend_name }}
     timeout connect {{ backend.application_data.timeout.connect }}
     timeout queue {{ backend.application_data.timeout.queue }}
 
-    option httpchk {% if backend.application_data.check.path %}GET {{ backend.application_data.check.path }}{% endif %}
-    # Some application ( like pollen ) doesn't care about the generated ingress URL and thus does not expect healthcheck requests to come with a header.
-    # In those cases haproxy will refuse to proxy incoming requests and replied with 503.
-    # Until we find a more suitable solution we won't send host headers in httpchk.
-    # http-check send hdr Host {{ backend.hostname_acls[0] }}
+    option httpchk {% if backend.application_data.check.path %}GET {{ backend.application_data.check.path }}
+    {% endif %}
+    {% if backend.application_data.check.port %}http-check connect port {{ backend.application_data.check.port }}
+    {% endif %}
+    http-check send hdr Host {{ backend.hostname_acls[0] }}
 {% if backend.application_data.rate_limit %}
     http-request track-sc0 src table  haproxy_peers/{{ backend.backend_name }}_rate_limit
     http-request {{ backend.application_data.rate_limit.policy.value }} if { sc_http_req_rate(0,haproxy_peers/{{ backend.backend_name }}_rate_limit) gt {{ backend.application_data.rate_limit.connections_per_minute }} }

--- a/tests/integration/haproxy_route_requirer.py
+++ b/tests/integration/haproxy_route_requirer.py
@@ -44,6 +44,7 @@ class AnyCharm(AnyCharmBase):
             check_rise=3,
             check_fall=3,
             check_path="/ok",
+            check_port=80,
             path_rewrite_expressions=["/ok"],
             deny_paths=["/private"],
         )


### PR DESCRIPTION
Add `check-port` attribute to the requirer databag model allowing charms to customize the port used for http-check 

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
