### PR TITLE
update template to add missing newlines, add unit_address arg to provide_haproxy_route_requirements

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
-*       @Thanhphan1147  @amandahla  @arturo-seijas
-requirements.txt	@canonical/is-charms
-/docs/ @erinecon
+# Ignore changelog from codeowner requests
+docs/changelog.md
+
+docs/*	@erinecon

--- a/lib/charms/haproxy/v0/haproxy_route.py
+++ b/lib/charms/haproxy/v0/haproxy_route.py
@@ -142,7 +142,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
@@ -949,6 +949,7 @@ class HaproxyRouteRequirer(Object):
         connect_timeout: int = 60,
         queue_timeout: int = 60,
         server_maxconn: Optional[int] = None,
+        unit_address: Optional[str] = None,
     ) -> None:
         """Update haproxy-route requirements data in the relation.
 
@@ -980,7 +981,9 @@ class HaproxyRouteRequirer(Object):
             connect_timeout: Timeout for client requests to haproxy in seconds.
             queue_timeout: Timeout for requests waiting in queue in seconds.
             server_maxconn: Maximum connections per server.
+            unit_address: IP address of the unit (if not provided, will use binding address).
         """
+        self._unit_address = unit_address
         self._application_data = self._generate_application_data(
             service,
             ports,

--- a/templates/haproxy_route.cfg.j2
+++ b/templates/haproxy_route.cfg.j2
@@ -39,8 +39,10 @@ backend {{ backend.backend_name }}
 
     option httpchk {% if backend.application_data.check.path %}GET {{ backend.application_data.check.path }}
     {% endif %}
+
     {% if backend.application_data.check.port %}http-check connect port {{ backend.application_data.check.port }}
     {% endif %}
+
     http-check send hdr Host {{ backend.hostname_acls[0] }}
 {% if backend.application_data.rate_limit %}
     http-request track-sc0 src table  haproxy_peers/{{ backend.backend_name }}_rate_limit


### PR DESCRIPTION
The haproxy-route j2 template was not spaced correctly which can cause some problems when rendering the haproxy config.

This PR also adds the possibility of specifying the unit_address in `provide_haproxy_route_requirements` helper method which was missing in previous lib versions.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
