### PR TITLE
set subordinate charm units to 1 due to potential bug in the tf provider

### DIFF
--- a/src/state/config.py
+++ b/src/state/config.py
@@ -9,7 +9,7 @@ import typing
 
 # bandit flags import subprocess as a low security issue
 # We disable it here as it's simply a heads-up for potential issues
-from subprocess import STDOUT, CalledProcessError, check_output  # nosec import_subprocess
+from subprocess import STDOUT, CalledProcessError, check_output  # nosec
 
 import ops
 from pydantic import Field, ValidationError, field_validator

--- a/src/state/config.py
+++ b/src/state/config.py
@@ -9,7 +9,7 @@ import typing
 
 # bandit flags import subprocess as a low security issue
 # We disable it here as it's simply a heads-up for potential issues
-from subprocess import STDOUT, CalledProcessError, check_output  # nosec B404
+from subprocess import STDOUT, CalledProcessError, check_output  # nosec import_subprocess
 
 import ops
 from pydantic import Field, ValidationError, field_validator

--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -31,7 +31,7 @@ resource "juju_application" "hacluster" {
   count = var.use_hacluster ? 1 : 0
   name  = var.hacluster_app_name
   model = var.model
-  units = var.units
+  units = 1
 
   charm {
     name     = "hacluster"

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -28,7 +28,7 @@ module "haproxy" {
 resource "juju_application" "grafana_agent" {
   name  = "grafana-agent"
   model = data.juju_model.haproxy.name
-  units = var.haproxy.units
+  units = 1
 
   charm {
     name     = "grafana-agent"


### PR DESCRIPTION
Tested locally and it does seem that during `terraform refresh` the provider always read the number of subordinate charm units as `1`

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
