### PR TITLE
pin haproxy version to 2.8.5-1ubuntu3.3

### DIFF
--- a/src/haproxy.py
+++ b/src/haproxy.py
@@ -16,7 +16,7 @@ from state.config import CharmConfig
 from state.haproxy_route import HaproxyRouteRequirersInformation
 from state.ingress import IngressRequirersInformation
 
-APT_PACKAGE_VERSION = "2.8.5-1ubuntu3"
+APT_PACKAGE_VERSION = "2.8.5-1ubuntu3.3"
 APT_PACKAGE_NAME = "haproxy"
 HAPROXY_CONFIG_DIR = Path("/etc/haproxy")
 HAPROXY_CONFIG = Path(HAPROXY_CONFIG_DIR / "haproxy.cfg")
@@ -65,8 +65,9 @@ class HAProxyService:
         Raises:
             RuntimeError: If the service is not running after installation.
         """
-        apt.update()
-        apt.add_package(package_names=APT_PACKAGE_NAME, version=APT_PACKAGE_VERSION)
+        apt.add_package(
+            package_names=APT_PACKAGE_NAME, version=APT_PACKAGE_VERSION, update_cache=True
+        )
 
         render_file(HAPROXY_DHCONFIG, HAPROXY_DH_PARAM, 0o644)
         self._reload_haproxy_service()

--- a/tests/unit/test_haproxy_service.py
+++ b/tests/unit/test_haproxy_service.py
@@ -16,16 +16,14 @@ def test_deploy(monkeypatch: pytest.MonkeyPatch):
     act: Call haproxy_service.install().
     assert: The apt mocks are called once.
     """
-    apt_update_mock = MagicMock()
-    monkeypatch.setattr("charms.operator_libs_linux.v0.apt.update", apt_update_mock)
     apt_add_package_mock = MagicMock()
     monkeypatch.setattr("charms.operator_libs_linux.v0.apt.add_package", apt_add_package_mock)
     render_file_mock = MagicMock()
     monkeypatch.setattr("haproxy.render_file", render_file_mock)
+    monkeypatch.setattr("haproxy.run", MagicMock())
 
     haproxy_service = HAProxyService()
     haproxy_service.install()
 
-    apt_update_mock.assert_called_once()
     apt_add_package_mock.assert_called_once()
     render_file_mock.assert_called_once_with(HAPROXY_DHCONFIG, HAPROXY_DH_PARAM, 0o644)


### PR DESCRIPTION
With `2.8.5-1ubuntu3.3` available, running `apt install -y haproxy=2.8.5-1ubuntu3` will result in the following error:

```
charms.operator_libs_linux.v0.apt.PackageError: Could not install package(s) ['haproxy=2.8.5-1ubuntu3']: E: Packages were downgraded and -y was used without --allow-downgrades.
```

Also added a call to `apt-mark hold haproxy` to pin the haproxy version and prevent automatic updates. 


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
