### PR TITLE
Add contents section to index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,10 @@ haproxy-operator is an open-source software operator that deploys and operates H
 The haproxy-operator offers advanced features such as TLS, monitoring and high-availability.
 
 > This operator is built for **IAAS/VM** and is not supported in **Kubernetes** environments
+
+# Contents
+1. [Tutorial](getting-started.md)
+1. [How-to guides](how-to)
+  1. [Configure a virtual IP on OpenStack](how-to/configure-virtual-ip-on-openstack.md)
+1. [Explanation](explanation)
+  1. [High availability](explanation/high-availability.md)    


### PR DESCRIPTION
### Overview

Add `# Contents` section to documentation overview page.

### Rationale

This section is necessary for discourse-gatekeeper to properly connect all the documentation pages when syncing to Charmhub. This also might resolve issues where discourse-gatekeeper tries to remove documentation on GitHub, like in https://github.com/canonical/haproxy-operator/pull/127

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No documentation to generate with `src-docs`. Documentation on Charmhub will be updated through discourse-gatekeeper or after the approval of this PR.