### PR TITLE
ISD-3795 update certificate handling, update tests, request cert for haproxy-route backends using subdomains

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -331,11 +331,6 @@ class HAProxyCharm(ops.CharmBase):
                 logger.exception(
                     "haproxy-route information not ready, skipping certificate request."
                 )
-                return [
-                    CertificateRequestAttributes(
-                        common_name=external_hostname, sans_dns=frozenset([external_hostname])
-                    )
-                ]
         return [
             CertificateRequestAttributes(
                 common_name=external_hostname, sans_dns=frozenset([external_hostname])

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,7 +25,7 @@ from charms.traefik_k8s.v2.ingress import (
     IngressPerAppDataRemovedEvent,
     IngressPerAppProvider,
 )
-from interface_hacluster.ops_ha_interface import HAServiceReadyEvent, HAServiceRequires
+from interface_hacluster.ops_ha_interface import HAServiceRequires
 from ops.charm import ActionEvent
 from ops.model import Port
 
@@ -39,9 +39,13 @@ from http_interface import (
 from state.config import CharmConfig
 from state.exception import CharmStateValidationBaseError
 from state.ha import HACLUSTER_INTEGRATION, HAPROXY_PEER_INTEGRATION, HAInformation
-from state.haproxy_route import HAPROXY_ROUTE_RELATION, HaproxyRouteRequirersInformation
+from state.haproxy_route import (
+    HAPROXY_ROUTE_RELATION,
+    HaproxyRouteIntegrationDataValidationError,
+    HaproxyRouteRequirersInformation,
+)
 from state.ingress import IngressRequirersInformation
-from state.tls import TLSInformation
+from state.tls import TLSInformation, TLSNotReadyError
 from state.validation import validate_config_and_tls
 from tls_relation import TLSRelationService
 
@@ -102,17 +106,22 @@ class HAProxyCharm(ops.CharmBase):
         # Order is important here as we want _ensure_tls to check if the hostname is configured
         self.framework.observe(self.on[TLS_CERT_RELATION].relation_created, self._ensure_tls)
         self.framework.observe(self.on[TLS_CERT_RELATION].relation_changed, self._ensure_tls)
+        self._ingress_provider = IngressPerAppProvider(charm=self, relation_name=INGRESS_RELATION)
+        self.reverseproxy_requirer = HTTPRequirer(self, REVERSE_PROXY_RELATION)
+        self.haproxy_route_provider = HaproxyRouteProvider(self)
         self.certificates = TLSCertificatesRequiresV4(
             charm=self,
             relationship_name=TLS_CERT_RELATION,
             certificate_requests=self._get_certificate_requests(),
-            refresh_events=[self.on.config_changed],
+            refresh_events=[
+                self.on.config_changed,
+                self.haproxy_route_provider.on.data_available,
+                self.haproxy_route_provider.on.data_removed,
+            ],
             mode=Mode.UNIT,
         )
 
         self._tls = TLSRelationService(self.model, self.certificates)
-        self._ingress_provider = IngressPerAppProvider(charm=self, relation_name=INGRESS_RELATION)
-        self.reverseproxy_requirer = HTTPRequirer(self, REVERSE_PROXY_RELATION)
         self.website_requirer = HTTPProvider(self, WEBSITE_RELATION)
 
         self._grafana_agent = COSAgentProvider(
@@ -124,10 +133,9 @@ class HAProxyCharm(ops.CharmBase):
         )
 
         self.hacluster = HAServiceRequires(self, HACLUSTER_INTEGRATION)
-        self.haproxy_route_provider = HaproxyRouteProvider(self)
-        self.framework.observe(self.on.install, self._on_config_changed)
+        self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
-        self.framework.observe(self.on.upgrade_charm, self._on_config_changed)
+        self.framework.observe(self.on.upgrade_charm, self._on_install)
         self.framework.observe(self.on.get_certificate_action, self._on_get_certificate_action)
         self.framework.observe(
             self.certificates.on.certificate_available, self._on_certificate_available
@@ -144,13 +152,19 @@ class HAProxyCharm(ops.CharmBase):
         self.framework.observe(
             self._ingress_provider.on.data_removed, self._on_ingress_data_removed
         )
-        self.framework.observe(self.hacluster.on.ha_ready, self._on_ha_ready)
+        self.framework.observe(self.hacluster.on.ha_ready, self._on_config_changed)
         self.framework.observe(
-            self.haproxy_route_provider.on.data_available, self._configure_haproxy_route
+            self.haproxy_route_provider.on.data_available, self._on_config_changed
         )
         self.framework.observe(
-            self.haproxy_route_provider.on.data_removed, self._configure_haproxy_route
+            self.haproxy_route_provider.on.data_removed, self._on_config_changed
         )
+
+    @validate_config_and_tls(defer=False)
+    def _on_install(self, _: typing.Any) -> None:
+        """Install the haproxy service and reconcile."""
+        self.haproxy_service.install()
+        self._reconcile()
 
     @validate_config_and_tls(defer=False)
     def _on_config_changed(self, _: typing.Any) -> None:
@@ -195,7 +209,6 @@ class HAProxyCharm(ops.CharmBase):
 
     def _reconcile(self) -> None:
         """Render the haproxy config and restart the service."""
-        self.haproxy_service.install()
         self.unit.status = ops.MaintenanceStatus("Configuring haproxy.")
         proxy_mode = self._validate_state()
         if proxy_mode == ProxyMode.INVALID:
@@ -252,7 +265,7 @@ class HAProxyCharm(ops.CharmBase):
                 haproxy_route_requirers_information = (
                     HaproxyRouteRequirersInformation.from_provider(
                         self.haproxy_route_provider,
-                        tls_information,
+                        tls_information.external_hostname,
                         self._get_peer_units_address(),
                     )
                 )
@@ -295,6 +308,34 @@ class HAProxyCharm(ops.CharmBase):
         external_hostname = typing.cast(str, self.config.get("external-hostname", None))
         if not external_hostname:
             return []
+
+        if self.haproxy_route_provider.relations and not (
+            self.reverseproxy_requirer.relations or self._ingress_provider.relations
+        ):
+            try:
+                haproxy_route_requirer_information = (
+                    HaproxyRouteRequirersInformation.from_provider(
+                        self.haproxy_route_provider,
+                        external_hostname,
+                        self._get_peer_units_address(),
+                    )
+                )
+                return [
+                    CertificateRequestAttributes(
+                        common_name=hostname_acl, sans_dns=frozenset([hostname_acl])
+                    )
+                    for backend in haproxy_route_requirer_information.backends
+                    for hostname_acl in backend.hostname_acls
+                ]
+            except (HaproxyRouteIntegrationDataValidationError, TLSNotReadyError):
+                logger.exception(
+                    "haproxy-route information not ready, skipping certificate request."
+                )
+                return [
+                    CertificateRequestAttributes(
+                        common_name=external_hostname, sans_dns=frozenset([external_hostname])
+                    )
+                ]
         return [
             CertificateRequestAttributes(
                 common_name=external_hostname, sans_dns=frozenset([external_hostname])
@@ -352,11 +393,6 @@ class HAProxyCharm(ops.CharmBase):
 
         return ProxyMode.NOPROXY
 
-    @validate_config_and_tls(defer=False)
-    def _on_ha_ready(self, _: HAServiceReadyEvent) -> None:
-        """Handle the ha-ready event."""
-        self._reconcile()
-
     def _reconcile_ha(self, ha_information: HAInformation) -> None:
         """Update ha configuration.
 
@@ -382,14 +418,6 @@ class HAProxyCharm(ops.CharmBase):
         self.hacluster.add_systemd_service(f"{self.app.name}-{HAPROXY_SERVICE}", HAPROXY_SERVICE)
         self.hacluster.bind_resources()
         peer_relation.data[self.unit].update({"vip": str(ha_information.vip)})
-
-    @validate_config_and_tls(defer=False)
-    def _configure_haproxy_route(self, _: HAServiceReadyEvent) -> None:
-        """Handle the ha-ready event."""
-        data = self.haproxy_route_provider.get_data(self.haproxy_route_provider.relations)
-        # This is temporary as the logic to generate the haproxy config will be added later.
-        logger.debug("Aggregated requirer data: %s", data)
-        self._reconcile()
 
     @validate_config_and_tls(defer=True)
     def _ensure_tls(self, _: ops.EventBase) -> None:

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -20,8 +20,6 @@ from pydantic import IPvAnyAddress, model_validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self
 
-from state.tls import TLSInformation
-
 from .exception import CharmStateValidationBaseError
 
 HAPROXY_ROUTE_RELATION = "haproxy-route"
@@ -183,13 +181,13 @@ class HaproxyRouteRequirersInformation:
 
     @classmethod
     def from_provider(
-        cls, haproxy_route: HaproxyRouteProvider, tls_information: TLSInformation, peers: list[str]
+        cls, haproxy_route: HaproxyRouteProvider, external_hostname: str, peers: list[str]
     ) -> "HaproxyRouteRequirersInformation":
         """Initialize the HaproxyRouteRequirersInformation state component.
 
         Args:
             haproxy_route: The haproxy-route provider class.
-            tls_information: The charm's TLS information state component.
+            external_hostname: The charm's configured hostname.
             peers: List of IP address of haproxy peer units.
 
         Raises:
@@ -218,7 +216,7 @@ class HaproxyRouteRequirersInformation:
                     relation_id=requirer.relation_id,
                     application_data=requirer.application_data,
                     servers=get_servers_definition_from_requirer_data(requirer),
-                    external_hostname=tls_information.external_hostname,
+                    external_hostname=external_hostname,
                 )
                 backends.append(backend)
 

--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -53,16 +53,13 @@ class TLSRelationService:
         """
         if len(self.certificates.certificate_requests) == 0:
             return None
-        provider_certificate, _ = self.certificates.get_assigned_certificate(
-            certificate_request=self.certificates.certificate_requests[0]
-        )
-        if not provider_certificate:
-            return None
-        if not provider_certificate.certificate:
-            return None
-        if provider_certificate.certificate.common_name != hostname:
-            return None
-        return provider_certificate
+
+        provider_certificates, _ = self.certificates.get_assigned_certificates()
+        for provider_cert in provider_certificates:
+            if provider_cert.certificate and provider_cert.certificate.common_name == hostname:
+                return provider_cert
+
+        return None
 
     def certificate_available(self, tls_information: TLSInformation) -> None:
         """Handle TLS Certificate available event.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -67,6 +67,13 @@ def mock_certificate_fixture(
         ),
         MagicMock(return_value=(provider_cert_mock, private_key)),
     )
+    monkeypatch.setattr(
+        (
+            "charms.tls_certificates_interface.v4.tls_certificates"
+            ".TLSCertificatesRequiresV4.get_assigned_certificates"
+        ),
+        MagicMock(return_value=([provider_cert_mock], private_key)),
+    )
     return certificate, private_key
 
 
@@ -99,6 +106,7 @@ def context_with_install_mock_fixture():
         patch("haproxy.HAProxyService.install") as install_mock,
         patch("haproxy.HAProxyService.reconcile_default") as reconcile_default_mock,
         patch("haproxy.HAProxyService.reconcile_ingress") as reconcile_ingress_mock,
+        patch("tls_relation.TLSRelationService.write_certificate_to_unit"),
     ):
         yield (
             Context(

--- a/tests/unit/test_haproxy_route_state.py
+++ b/tests/unit/test_haproxy_route_state.py
@@ -3,8 +3,6 @@
 
 """Unit tests for haproxy-route relation."""
 
-from unittest.mock import MagicMock
-
 import pytest
 from charms.haproxy.v0.haproxy_route import (
     LoadBalancingAlgorithm,
@@ -101,10 +99,8 @@ def test_haproxy_route_from_provider(
     )
 
     harness.begin()
-    tls_information = MagicMock()
-    tls_information.external_hostname = MOCK_EXTERNAL_HOSTNAME
     haproxy_route_information = HaproxyRouteRequirersInformation.from_provider(
-        harness.charm.haproxy_route_provider, tls_information, haproxy_peer_units_address
+        harness.charm.haproxy_route_provider, MOCK_EXTERNAL_HOSTNAME, haproxy_peer_units_address
     )
 
     assert len(haproxy_route_information.backends) == 2
@@ -157,12 +153,12 @@ def test_haproxy_route_from_provider_duplicate_backend_names(
     harness.update_relation_data(
         extra_relation_id, "extra-requirer-charm/0", generate_unit_data("10.0.0.3")
     )
-    tls_information = MagicMock()
-    tls_information.external_hostname = MOCK_EXTERNAL_HOSTNAME
 
     harness.begin()
     # Act & Assert
     with pytest.raises(HaproxyRouteIntegrationDataValidationError):
         HaproxyRouteRequirersInformation.from_provider(
-            harness.charm.haproxy_route_provider, tls_information, peers=[]
+            haproxy_route=harness.charm.haproxy_route_provider,
+            external_hostname=MOCK_EXTERNAL_HOSTNAME,
+            peers=[],
         )


### PR DESCRIPTION
Currently haproxy only request cert for the external-hostname config, if a haproxy-route requirer charm requested a subdomain the resulting fqdn should also have a certificate.

In this PR we request a new cert for each subdomain during initialization. The prototype of the haproxy-route state component is also changed slightly to accomodate this ( This is because we need to parse the haproxy-route relation data during charm init and during the initialization of the certificates requirer ). Some minor bug fixes for certificates handling and some updates to unit test is also present.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
