### PR TITLE
Feat add protocol field to haproxy route charm lib

### DIFF
--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -31,21 +31,24 @@ class SomeCharm(CharmBase):
     # There are 2 ways you can use the requirer implementation:
     # 1. To initialize the requirer with parameters:
     self.haproxy_route_requirer = HaproxyRouteRequirer(self,
-        address=<required>,
-        port=<required>,
+        relation_name=<required>,
+        service=<optional>,
+        ports=<optional>,
+        hosts=<optional>,
         paths=<optional>,
         hostname=<optional>,
         additional_hostnames=<optional>,
-        path_rewrite_expressions=<optional>, list of path rewrite expressions,
-        query_rewrite_expressions=<optional>, list of query rewrite expressions,
-        header_rewrites=<optional>, map of {<header_name>: <list of rewrite_expressions>,
         check_interval=<optional>,
         check_rise=<optional>,
         check_fall=<optional>,
-        check_paths=<optional>,
+        check_path=<optional>,
+        check_port=<optional>,
+        path_rewrite_expressions=<optional>, list of path rewrite expressions,
+        query_rewrite_expressions=<optional>, list of query rewrite expressions,
+        header_rewrite_expressions=<optional>, list of (header_name, rewrite_expression),
         load_balancing_algorithm=<optional>, defaults to "leastconn",
         load_balancing_cookie=<optional>, only used when load_balancing_algorithm is cookie
-        rate_limit_connections_per_minutes=<optional>,
+        rate_limit_connections_per_minute=<optional>,
         rate_limit_policy=<optional>,
         upload_limit=<optional>,
         download_limit=<optional>,
@@ -57,6 +60,7 @@ class SomeCharm(CharmBase):
         connect_timeout=<optional>,
         queue_timeout=<optional>,
         server_maxconn=<optional>,
+        unit_address=<optional>,
     )
 
     # 2.To initialize the requirer with no parameters, i.e

--- a/tests/unit/legacy/test_haproxy_route_lib.py
+++ b/tests/unit/legacy/test_haproxy_route_lib.py
@@ -42,6 +42,7 @@ def mock_relation_data_fixture():
     return {
         "service": "test-service",
         "ports": [8080],
+        "protocol": "http",
         "hosts": ["10.0.0.1", "10.0.0.2"],
         "paths": ["/api"],
         "hostname": "api.haproxy.internal",
@@ -194,6 +195,23 @@ def test_requirers_data_duplicate_services():
         HaproxyRouteRequirersData(
             requirers_data=[requirer_data1, requirer_data2], relation_ids_with_invalid_data=[]
         )
+
+
+def test_load_legacy_requirer_application_data(mock_relation_data):
+    """Validate that databag can be loaded from older version of the library."""
+    databag = {k: json.dumps(v) for k, v in mock_relation_data.items()}
+    databag.pop("protocol")
+    data = RequirerApplicationData.load(databag)
+
+    assert data.service == "test-service"
+    assert data.ports == [8080]
+    assert data.hosts == [IPv4Address("10.0.0.1"), IPv4Address("10.0.0.2")]
+    assert data.paths == ["/api"]
+    assert data.hostname == "api.haproxy.internal"
+    assert data.check.interval == 60
+    assert data.check.rise == 2
+    assert data.check.fall == 3
+    assert data.check.path == "/health"
 
 
 def test_load_requirer_application_data(mock_relation_data):

--- a/tests/unit/legacy/test_haproxy_route_lib.py
+++ b/tests/unit/legacy/test_haproxy_route_lib.py
@@ -225,6 +225,7 @@ def test_load_requirer_application_data(mock_relation_data):
 
     assert data.service == "test-service"
     assert data.ports == [8080]
+    assert data.protocol == "http"
     assert data.hosts == [IPv4Address("10.0.0.1"), IPv4Address("10.0.0.2")]
     assert data.paths == ["/api"]
     assert data.hostname == "api.haproxy.internal"

--- a/tests/unit/legacy/test_haproxy_route_lib.py
+++ b/tests/unit/legacy/test_haproxy_route_lib.py
@@ -205,6 +205,7 @@ def test_load_legacy_requirer_application_data(mock_relation_data):
 
     assert data.service == "test-service"
     assert data.ports == [8080]
+    assert data.protocol == "http"  # the default value
     assert data.hosts == [IPv4Address("10.0.0.1"), IPv4Address("10.0.0.2")]
     assert data.paths == ["/api"]
     assert data.hostname == "api.haproxy.internal"


### PR DESCRIPTION
Applicable spec: https://docs.google.com/document/d/1NbjHuynMMsYwGMJaq8N9M70dyZgbxqBElz2aYocp5EM/edit?tab=t.0

### Overview

Adds the "protocol" field to the requirer application databag.

### Rationale

To support HTTPS upstream servers.

### Juju Events Changes

none

### Module Changes

none

### Library Changes

haproxy-route: adds the protocol field to the requirer application databag.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was appxied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->


Note: this PR is build on top of #163 
