### PR TITLE
render retry configuration in template, remove retry_interval attribute

### DIFF
--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -768,7 +768,12 @@ class HaproxyRouteProvider(Object):
         requirer_units_data: list[RequirerUnitData] = []
 
         for unit in relation.units:
-            databag = relation.data[unit]
+            databag = relation.data.get(unit)
+            if not databag:
+                logger.error(
+                    "Requirer unit data does not exist even though the unit is still present."
+                )
+                continue
             try:
                 data = cast(RequirerUnitData, RequirerUnitData.load(databag))
                 requirer_units_data.append(data)

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -143,7 +143,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"

--- a/templates/haproxy_route.cfg.j2
+++ b/templates/haproxy_route.cfg.j2
@@ -34,6 +34,12 @@ backend {{ backend.backend_name }}
     timeout server {{ backend.application_data.timeout.server }}s
     timeout connect {{ backend.application_data.timeout.connect }}s
     timeout queue {{ backend.application_data.timeout.queue }}s
+{% if backend.application_data.retry %}
+    retries {{ backend.application_data.retry.count }}
+{% if backend.application_data.retry.redispatch %}
+    option redispatch
+{% endif %}
+{% endif %}
 
     option httpchk {% if backend.application_data.check.path %}GET {{ backend.application_data.check.path }}{% endif +%}
 {% if backend.application_data.check.port %}

--- a/tests/integration/legacy/conftest.py
+++ b/tests/integration/legacy/conftest.py
@@ -21,7 +21,6 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 TEST_EXTERNAL_HOSTNAME_CONFIG = "haproxy.internal"
-GATEWAY_CLASS_CONFIG = "cilium"
 HAPROXY_ROUTE_REQUIRER_SRC = "tests/integration/legacy/haproxy_route_requirer.py"
 HAPROXY_ROUTE_LIB_SRC = "lib/charms/haproxy/v1/haproxy_route.py"
 APT_LIB_SRC = "lib/charms/operator_libs_linux/v0/apt.py"

--- a/tests/integration/legacy/haproxy_route_requirer.py
+++ b/tests/integration/legacy/haproxy_route_requirer.py
@@ -57,3 +57,12 @@ class AnyCharm(AnyCharmBase):
             check_path="/",
             check_port=80,
         )
+
+    def update_relation_retry(self):
+        """Update relation details for haproxy-route with retry configuration."""
+        self._haproxy_route.provide_haproxy_route_requirements(
+            service="any_charm_with_retry",
+            ports=[80],
+            retry_count=3,
+            retry_redispatch=True,
+        )

--- a/tests/integration/test_haproxy_route.py
+++ b/tests/integration/test_haproxy_route.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for the ingress per unit relation."""
+
+
+import jubilant
+import pytest
+
+
+@pytest.mark.abort_on_fail
+async def test_haproxy_route_ingress_configurator(
+    configured_application_with_tls: str,
+    ingress_configurator: str,
+    juju: jubilant.Juju,
+):
+    """Deploy the charm with anycharm ingress per unit requirer that installs apache2.
+
+    Assert that the requirer endpoints are available.
+    """
+    juju.integrate(configured_application_with_tls, ingress_configurator)
+    # We set the removed retry-interval config option here as
+    # ingress-configurator is not yet synced with the updated lib. This will be removed.
+    juju.config(
+        ingress_configurator,
+        values={"retry-count": 3, "retry-interval": 1, "retry-redispatch": True},
+    )
+    juju.wait(
+        lambda status: jubilant.all_active(
+            status, configured_application_with_tls, ingress_configurator
+        )
+    )
+    haproxy_config = juju.ssh(
+        f"{configured_application_with_tls}/leader", "cat /etc/haproxy/haproxy.cfg"
+    )
+    assert all(entry in haproxy_config for entry in ["retries 3", "option redispatch"])


### PR DESCRIPTION
The `retry_interval` attribute is removed since there's no way to configure that in HAproxy. To configure the time between 2 retries we can use `timeout.connect`.

Fixes #160 

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
