### PR TITLE
ISD-3954 add consistent hashing

### DIFF
--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -49,7 +49,7 @@ class SomeCharm(CharmBase):
         header_rewrite_expressions=<optional>, list of (header_name, rewrite_expression),
         load_balancing_algorithm=<optional>, defaults to "leastconn",
         load_balancing_cookie=<optional>, only used when load_balancing_algorithm is cookie
-        load_balancing_consistent_hashing=<optional>, to enable consistent hashing, 
+        load_balancing_consistent_hashing=<optional>, to enable consistent hashing,
             defaults to False,
         rate_limit_connections_per_minute=<optional>,
         rate_limit_policy=<optional>,

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -393,6 +393,38 @@ class LoadBalancingConfiguration(BaseModel):
         description="Only used when algorithm is COOKIE. Define the cookie to load balance on.",
         default=None,
     )
+    # Note: Later when LoadBalancingAlgorithm.HASH is implemented this attribute will also apply
+    # under that mode.
+    consistent_hashing: bool = Field(
+        description=(
+            "Only used when the `algorithm` is SRCIP or COOKIE. "
+            "Use consistent hashing to avoid redirection when servers are added/removed. "
+            "Default is False as it usually does not give a balanced distribution."
+        ),
+        default=False,
+    )
+
+    @model_validator(mode="after")
+    def validate_attributes(self) -> Self:
+        """Check that algorithm-specific configs are only set with their respective algorithm.
+
+        Raises:
+            ValueError: When validation fails in one of these cases:
+                1. self.cookie is not None when self.algorithm != COOKIE
+                2. self.consistent_hashing is True when algorithm is neither COOKIE nor SRCIP
+
+        Returns:
+            The validated model.
+        """
+        if self.cookie is not None and self.algorithm != LoadBalancingAlgorithm.COOKIE:
+            raise ValueError("cookie only applies when algorithm is COOKIE.")
+
+        if self.consistent_hashing and self.algorithm not in [
+            LoadBalancingAlgorithm.COOKIE,
+            LoadBalancingAlgorithm.SRCIP,
+        ]:
+            raise ValueError("Consistent hashing only applies when algorithm is COOKIE or SRCIP.")
+        return self
 
 
 class BandwidthLimit(BaseModel):
@@ -890,6 +922,7 @@ class HaproxyRouteRequirer(Object):
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
         load_balancing_algorithm: LoadBalancingAlgorithm = LoadBalancingAlgorithm.LEASTCONN,
         load_balancing_cookie: Optional[str] = None,
+        load_balancing_consistent_hashing: bool = False,
         rate_limit_connections_per_minute: Optional[int] = None,
         rate_limit_policy: RateLimitPolicy = RateLimitPolicy.DENY,
         upload_limit: Optional[int] = None,
@@ -926,6 +959,7 @@ class HaproxyRouteRequirer(Object):
                 and rewrite expression.
             load_balancing_algorithm: Algorithm to use for load balancing.
             load_balancing_cookie: Cookie name to use when algorithm is set to cookie.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
             rate_limit_connections_per_minute: Maximum connections allowed per minute.
             rate_limit_policy: Policy to apply when rate limit is reached.
             upload_limit: Maximum upload bandwidth in bytes per second.
@@ -965,6 +999,7 @@ class HaproxyRouteRequirer(Object):
             header_rewrite_expressions,
             load_balancing_algorithm,
             load_balancing_cookie,
+            load_balancing_consistent_hashing,
             rate_limit_connections_per_minute,
             rate_limit_policy,
             upload_limit,
@@ -1018,6 +1053,7 @@ class HaproxyRouteRequirer(Object):
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
         load_balancing_algorithm: LoadBalancingAlgorithm = LoadBalancingAlgorithm.LEASTCONN,
         load_balancing_cookie: Optional[str] = None,
+        load_balancing_consistent_hashing: bool = False,
         rate_limit_connections_per_minute: Optional[int] = None,
         rate_limit_policy: RateLimitPolicy = RateLimitPolicy.DENY,
         upload_limit: Optional[int] = None,
@@ -1052,6 +1088,7 @@ class HaproxyRouteRequirer(Object):
                 and rewrite expression.
             load_balancing_algorithm: Algorithm to use for load balancing.
             load_balancing_cookie: Cookie name to use when algorithm is set to cookie.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
             rate_limit_connections_per_minute: Maximum connections allowed per minute.
             rate_limit_policy: Policy to apply when rate limit is reached.
             upload_limit: Maximum upload bandwidth in bytes per second.
@@ -1084,6 +1121,7 @@ class HaproxyRouteRequirer(Object):
             header_rewrite_expressions,
             load_balancing_algorithm,
             load_balancing_cookie,
+            load_balancing_consistent_hashing,
             rate_limit_connections_per_minute,
             rate_limit_policy,
             upload_limit,
@@ -1118,6 +1156,7 @@ class HaproxyRouteRequirer(Object):
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
         load_balancing_algorithm: LoadBalancingAlgorithm = LoadBalancingAlgorithm.LEASTCONN,
         load_balancing_cookie: Optional[str] = None,
+        load_balancing_consistent_hashing: bool = False,
         rate_limit_connections_per_minute: Optional[int] = None,
         rate_limit_policy: RateLimitPolicy = RateLimitPolicy.DENY,
         upload_limit: Optional[int] = None,
@@ -1151,6 +1190,7 @@ class HaproxyRouteRequirer(Object):
                 rewrite expression.
             load_balancing_algorithm: Algorithm to use for load balancing.
             load_balancing_cookie: Cookie name to use when algorithm is set to cookie.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
             rate_limit_connections_per_minute: Maximum connections allowed per minute.
             rate_limit_policy: Policy to apply when rate limit is reached.
             upload_limit: Maximum upload bandwidth in bytes per second.
@@ -1195,6 +1235,7 @@ class HaproxyRouteRequirer(Object):
             "load_balancing": {
                 "algorithm": load_balancing_algorithm,
                 "cookie": load_balancing_cookie,
+                "consistent_hashing": load_balancing_consistent_hashing,
             },
             "timeout": {
                 "server": server_timeout,

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -148,7 +148,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
@@ -383,6 +383,8 @@ class LoadBalancingConfiguration(BaseModel):
     Attributes:
         algorithm: Algorithm to use for load balancing.
         cookie: Cookie name to use when algorithm is set to cookie.
+        consistent_hashing: Use consistent hashing to avoid redirection
+            when servers are added/removed.
     """
 
     algorithm: LoadBalancingAlgorithm = Field(
@@ -393,8 +395,8 @@ class LoadBalancingConfiguration(BaseModel):
         description="Only used when algorithm is COOKIE. Define the cookie to load balance on.",
         default=None,
     )
-    # Note: Later when LoadBalancingAlgorithm.HASH is implemented this attribute will also apply
-    # under that mode.
+    # Note: Later when the generic LoadBalancingAlgorithm.HASH is implemented this attribute
+    # will also apply under that mode.
     consistent_hashing: bool = Field(
         description=(
             "Only used when the `algorithm` is SRCIP or COOKIE. "

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -49,6 +49,8 @@ class SomeCharm(CharmBase):
         header_rewrite_expressions=<optional>, list of (header_name, rewrite_expression),
         load_balancing_algorithm=<optional>, defaults to "leastconn",
         load_balancing_cookie=<optional>, only used when load_balancing_algorithm is cookie
+        load_balancing_consistent_hashing=<optional>, to enable consistent hashing, 
+            defaults to False,
         rate_limit_connections_per_minute=<optional>,
         rate_limit_policy=<optional>,
         upload_limit=<optional>,

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -148,7 +148,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
@@ -326,10 +326,7 @@ class ServerHealthCheck(BaseModel):
         Returns:
             The validated model.
         """
-        nb_fields_set = sum(
-            bool(value is not None) for value in [self.interval, self.rise, self.fall]
-        )
-        if nb_fields_set != 0 or nb_fields_set != 3:
+        if not (bool(self.interval) == bool(self.rise) == bool(self.fall)):
             raise ValueError("All three of interval, rise and fall must be set.")
         return self
 

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -326,7 +326,7 @@ class ServerHealthCheck(BaseModel):
         Returns:
             The validated model.
         """
-        if not (bool(self.interval) == bool(self.rise) == bool(self.fall)):
+        if not bool(self.interval) == bool(self.rise) == bool(self.fall):
             raise ValueError("All three of interval, rise and fall must be set.")
         return self
 

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -330,15 +330,6 @@ class ServerHealthCheck(BaseModel):
             raise ValueError("All three of interval, rise and fall must be set.")
         return self
 
-    @property
-    def is_health_check_configured(self) -> bool:
-        """Indicate if the backend has activated health checks.
-
-        Returns:
-            bool: Whether health check has been configured.
-        """
-        return sum(bool(value is not None) for value in [self.interval, self.rise, self.fall]) == 3
-
 
 # tarpit is not yet implemented
 class RateLimitPolicy(Enum):

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -135,6 +135,19 @@ class HAProxyRouteBackend:
         return str(self.application_data.load_balancing.algorithm.value)
 
     @property
+    def consistent_hashing(self) -> bool:
+        """Indicate if consistent hashing should be applied for this backend.
+
+        Returns:
+            bool: Whether consistent hashing should be applied.
+        """
+        return (
+            self.application_data.load_balancing.consistent_hashing
+            and self.application_data.load_balancing.algorithm
+            in [LoadBalancingAlgorithm.COOKIE, LoadBalancingAlgorithm.SRCIP]
+        )
+
+    @property
     def rewrite_configurations(self) -> list[str]:
         """Build the rewrite configurations.
 

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -49,6 +49,17 @@ class HAProxyRouteServer:
     check: Optional[ServerHealthCheck]
     maxconn: Optional[int]
 
+    @property
+    def is_health_check_configured(self) -> bool:
+        """Indicate if health check is configured and should be rendered.
+
+        Returns:
+            bool: When health check is configured and should be rendered.
+        """
+        return self.check and (
+            bool(self.check.interval) == bool(self.check.rise) == bool(self.check.fall)
+        )
+
 
 @dataclass(frozen=True)
 class HAProxyRouteBackend:

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -58,7 +58,7 @@ class HAProxyRouteServer:
         Returns:
             bool: When health check is configured and should be rendered.
         """
-        return self.check and (
+        return self.check is not None and (
             bool(self.check.interval) == bool(self.check.rise) == bool(self.check.fall)
         )
 

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -65,6 +65,8 @@ class HAProxyRouteBackend:
         rewrite_configurations: Rewrite configuration.
         path_acl_required: Indicate if path routing is required.
         deny_path_acl_required: Indicate if deny_path is required.
+        consistent_hashing: Use consistent hashing to avoid redirection
+            when servers are added/removed.
     """
 
     relation_id: int

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -51,17 +51,6 @@ class HAProxyRouteServer:
     check: Optional[ServerHealthCheck]
     maxconn: Optional[int]
 
-    @property
-    def is_health_check_configured(self) -> bool:
-        """Indicate if health check is configured and should be rendered.
-
-        Returns:
-            bool: When health check is configured and should be rendered.
-        """
-        return self.check is not None and (
-            bool(self.check.interval) == bool(self.check.rise) == bool(self.check.fall)
-        )
-
 
 @dataclass(frozen=True)
 class HAProxyRouteBackend:

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -41,8 +41,6 @@ class HAProxyRouteServer:
         port: The port that the requirer application wishes to be exposed.
         check: Health check configuration.
         maxconn: Maximum allowed connections before requests are queued.
-        is_health_check_configured: Indicate if health check is configured and
-            should be rendered.
     """
 
     server_name: str

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -41,6 +41,8 @@ class HAProxyRouteServer:
         port: The port that the requirer application wishes to be exposed.
         check: Health check configuration.
         maxconn: Maximum allowed connections before requests are queued.
+        is_health_check_configured: Indicate if health check is configured and
+            should be rendered.
     """
 
     server_name: str

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -46,7 +46,7 @@ class HAProxyRouteServer:
     server_name: str
     address: IPvAnyAddress
     port: int
-    check: ServerHealthCheck
+    check: Optional[ServerHealthCheck]
     maxconn: Optional[int]
 
 

--- a/templates/haproxy_route.cfg.j2
+++ b/templates/haproxy_route.cfg.j2
@@ -63,7 +63,7 @@ backend {{ backend.backend_name }}
     http-request {{ rewrite_configuration }}
 {% endfor %}
 {% for server in backend.servers %}
-    server {{ server.server_name }} {{ server.address }}:{{ server.port }} {% if server.is_health_check_configured %} check inter {{ server.check.interval }}s rise {{ server.check.rise }} fall {{ server.check.fall }} {% endif +%}
+    server {{ server.server_name }} {{ server.address }}:{{ server.port }} {% if server.check %} check inter {{ server.check.interval }}s rise {{ server.check.rise }} fall {{ server.check.fall }} {% endif +%}
 {% endfor %}
 
 {% endfor %}

--- a/templates/haproxy_route.cfg.j2
+++ b/templates/haproxy_route.cfg.j2
@@ -57,7 +57,7 @@ backend {{ backend.backend_name }}
     http-request {{ rewrite_configuration }}
 {% endfor %}
 {% for server in backend.servers %}
-    server {{ server.server_name }} {{ server.address }}:{{ server.port }} check inter {{ server.check.interval }}s rise {{ server.check.rise }} fall {{ server.check.fall }}
+    server {{ server.server_name }} {{ server.address }}:{{ server.port }} {% if server.is_health_check_configured %} check inter {{ server.check.interval }}s rise {{ server.check.rise }} fall {{ server.check.fall }} {% endif +%}
 {% endfor %}
 
 {% endfor %}

--- a/templates/haproxy_route.cfg.j2
+++ b/templates/haproxy_route.cfg.j2
@@ -31,6 +31,9 @@ peers haproxy_peers
 {% for backend in backends %}
 backend {{ backend.backend_name }}
     balance {{ backend.load_balancing_configuration }}
+{% if backend.consistent_hashing %}
+    hash-type consistent
+{% endif %}
     timeout server {{ backend.application_data.timeout.server }}s
     timeout connect {{ backend.application_data.timeout.connect }}s
     timeout queue {{ backend.application_data.timeout.queue }}s

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -185,7 +185,7 @@ def ingress_configurator_fixture(_pytestconfig: pytest.Config, juju: jubilant.Ju
         INGRESS_CONFIGURATOR_APPLICATION,
         app=INGRESS_CONFIGURATOR_APPLICATION,
         channel="edge",
-        revision=10,
+        revision=14,
         config={
             "backend-addresses": "10.0.0.1",
             "backend-ports": "80",

--- a/tests/integration/test_haproxy_route.py
+++ b/tests/integration/test_haproxy_route.py
@@ -23,7 +23,7 @@ async def test_haproxy_route_ingress_configurator(
     # ingress-configurator is not yet synced with the updated lib. This will be removed.
     juju.config(
         ingress_configurator,
-        values={"retry-count": 3, "retry-interval": 1, "retry-redispatch": True},
+        values={"retry-count": 3, "retry-redispatch": True},
     )
     juju.wait(
         lambda status: jubilant.all_active(
@@ -37,7 +37,7 @@ async def test_haproxy_route_ingress_configurator(
     juju.config(
         ingress_configurator,
         values={"load-balancing-algorithm": "source", "load-balancing-consistent-hashing": True},
-        reset=["retry-count", "retry-interval", "retry-redispatch"],
+        reset=["retry-count", "retry-redispatch"],
     )
     juju.wait(
         lambda status: jubilant.all_active(

--- a/tests/integration/test_haproxy_route.py
+++ b/tests/integration/test_haproxy_route.py
@@ -34,3 +34,5 @@ async def test_haproxy_route_ingress_configurator(
         f"{configured_application_with_tls}/leader", "cat /etc/haproxy/haproxy.cfg"
     )
     assert all(entry in haproxy_config for entry in ["retries 3", "option redispatch"])
+    # Integration tests for loadbalacing, cookie and consistent hashing will be added
+    # When the ingress-configurator charm is updated with the corresponding charm configs.

--- a/tests/unit/legacy/test_haproxy_route_lib.py
+++ b/tests/unit/legacy/test_haproxy_route_lib.py
@@ -449,6 +449,7 @@ def test_requirer_application_data_load_balancing_consistent_hashing_with_incorr
         )
 
 
+# pylint: disable=no-member
 def test_requirer_application_data_with_load_balancing_configuration():
     """
     arrange: Create a RequirerApplicationData model with mismatch load balancing configuration.

--- a/tests/unit/legacy/test_haproxy_route_lib.py
+++ b/tests/unit/legacy/test_haproxy_route_lib.py
@@ -399,3 +399,17 @@ def test_prepare_unit_data_no_address(mock_requirer_charm: Harness):
     with pytest.raises(DataValidationError):
         # We want to specifically test this method.
         requirer._prepare_unit_data()  # pylint: disable=protected-access
+
+
+def test_requirer_application_data_incomplete_health_check():
+    """
+    arrange: Create a RequirerApplicationData model with incomplete health check configuration.
+    act: Validate the model.
+    assert: DataValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        RequirerApplicationData(
+            service="test-service",
+            ports=[8080],
+            check=ServerHealthCheck(interval=60),
+        )

--- a/tests/unit/legacy/test_haproxy_route_lib.py
+++ b/tests/unit/legacy/test_haproxy_route_lib.py
@@ -18,6 +18,7 @@ from charms.haproxy.v1.haproxy_route import (
     HaproxyRouteRequirerData,
     HaproxyRouteRequirersData,
     LoadBalancingAlgorithm,
+    LoadBalancingConfiguration,
     RequirerApplicationData,
     RequirerUnitData,
     ServerHealthCheck,
@@ -413,3 +414,53 @@ def test_requirer_application_data_incomplete_health_check():
             ports=[8080],
             check=ServerHealthCheck(interval=60),
         )
+
+
+def test_requirer_application_data_mismatch_load_balancing_configuration():
+    """
+    arrange: Create a RequirerApplicationData model with mismatch load balancing configuration.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        RequirerApplicationData(
+            service="test-service",
+            ports=[8080],
+            load_balancing=LoadBalancingConfiguration(
+                algorithm=LoadBalancingAlgorithm.LEASTCONN, cookie="TEST", consistent_hashing=True
+            ),
+        )
+
+
+def test_requirer_application_data_load_balancing_consistent_hashing_with_incorrect_algorithm():
+    """
+    arrange: Create a RequirerApplicationData model with consistent_hashing enabled
+        and an incorrect algorithm.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        RequirerApplicationData(
+            service="test-service",
+            ports=[8080],
+            load_balancing=LoadBalancingConfiguration(
+                algorithm=LoadBalancingAlgorithm.LEASTCONN, consistent_hashing=True
+            ),
+        )
+
+
+def test_requirer_application_data_with_load_balancing_configuration():
+    """
+    arrange: Create a RequirerApplicationData model with mismatch load balancing configuration.
+    act: Validate the model.
+    assert: DataValidationError is raised.
+    """
+    application_data = RequirerApplicationData(
+        service="test-service",
+        ports=[8080],
+        load_balancing=LoadBalancingConfiguration(
+            algorithm=LoadBalancingAlgorithm.SRCIP, consistent_hashing=True
+        ),
+    )
+    assert application_data.load_balancing.algorithm == LoadBalancingAlgorithm.SRCIP
+    assert application_data.load_balancing.consistent_hashing is True


### PR DESCRIPTION
Consistent hashing reduce redistribution of clients to another backend server when server is added/removed. On haproxy it will add 
```
hash-type consistent
```
To its config

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
