### PR TITLE
Update tutorial to use ingress-configurator and local app

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -30,7 +30,7 @@ jobs:
           workspace = os.environ["GITHUB_WORKSPACE"]
           print(json.dumps(
             {
-              "any_charm.py": pathlib.Path(f"{workspace}/tests/integration/haproxy_route_requirer.py").read_text(
+              "any_charm.py": pathlib.Path(f"{workspace}/tests/integration/legacy/haproxy_route_requirer.py").read_text(
                 encoding="utf-8"
               ),
               "haproxy_route.py": pathlib.Path(f"{workspace}/lib/charms/haproxy/v1/haproxy_route.py").read_text(

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -16,31 +16,3 @@ jobs:
     secrets: inherit
     with:
       channel: 2.8/edge
-
-  generate-anycharm-json-artifact:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          python3 - <<'EOF' > /tmp/haproxy_route_requirer_src.json
-          import json
-          import pathlib
-          import os
-
-          workspace = os.environ["GITHUB_WORKSPACE"]
-          print(json.dumps(
-            {
-              "any_charm.py": pathlib.Path(f"{workspace}/tests/integration/legacy/haproxy_route_requirer.py").read_text(
-                encoding="utf-8"
-              ),
-              "haproxy_route.py": pathlib.Path(f"{workspace}/lib/charms/haproxy/v1/haproxy_route.py").read_text(
-                encoding="utf-8"
-              ),
-              "apt.py": pathlib.Path(f"{workspace}/lib/charms/operator_libs_linux/v0/apt.py").read_text(encoding="utf-8"),
-            }
-          ))
-          EOF
-      - uses: actions/upload-artifact@v4
-        with:
-          name: haproxy_route_requirer_src
-          path: /tmp/haproxy_route_requirer_src.json

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -25,5 +25,4 @@ header:
     - '.woke.yaml'
     - 'templates/**'
     - 'src/loki_alert_rules/*.rule'
-    - 'tests/integration/haproxy_route_requirer_src.json'
   comment: on-failure

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,7 +68,8 @@ In this tutorial we will use `any-charm` as the backend application. We will fet
 ```
 juju deploy any-charm requirer --channel beta --config src-overwrite="$(curl -L https://github.com/canonical/haproxy-operator/releases/download/rev141/haproxy_route_requirer_src.json)" --config python-packages="pydantic~=2.10"
 juju run requirer/0 rpc method=start_server
-juju integrate requirer haproxy
+juju integrate requirer haproxy:haproxy-route
+juju run requirer/0 rpc method=update_relation
 ```
 
 Let's check that the request has been properly proxied to the backend service. The `--insecure` option is needed here as we are using a self-signed certificate, as well as the `--resolve` option to manually perform a DNS lookup as HAProxy will issue an HTTPS redirect to `$HAPROXY_HOSTNAME`. Finally, `-L` is also needed to automatically follow redirects.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ juju deploy haproxy --channel=2.8/edge --base=ubuntu@24.04
 ```
 
 ## Configure TLS
-Haproxy enforces HTTPS when using the `ingress` integration. To set up the TLS for the HAProxy charm, deploy the `self-signed-certificates` charm as the `cert` application and integrate with the HAProxy charm.
+HAproxy enforces HTTPS when using the `ingress` integration. To set up the TLS for the HAProxy charm, deploy the `self-signed-certificates` charm as the `cert` application and integrate with the HAProxy charm.
 ```
 juju deploy self-signed-certificates cert
 juju integrate haproxy cert
@@ -45,7 +45,7 @@ Machine  State    Address         Inst id        Base          AZ  Message
 1        started  10.208.204.86   juju-1d3062-1  ubuntu@24.04      Running
 ```
 
-Note the IP address of the HAProxy unit; in the above example, the relevant IP address is `10.208.204.138`. Use that IP address to an environment variable named HAPROXY_IP. 
+Note the IP address of the HAProxy unit; in the above example, the relevant IP address is `10.208.204.138`. Use that IP address to an environment variable named `HAPROXY_IP`. 
 You can configure the IP from the output of `juju status` with:
 ```
 HAPROXY_IP=$(juju status --format json | jq -r '.applications.haproxy.units."haproxy/0"."public-address"')
@@ -61,10 +61,12 @@ If successful, the terminal will output:
 Default page for the haproxy-operator charm
 ```
 
+<!-- valeCanonical.007-Headings-sentence-case = NO -->
 ## Use the Ingress configurator charm to proxy a web server
+<!-- valeCanonical.007-Headings-sentence-case = YES -->
 
 The [Ingress configurator charm](https://charmhub.io/ingress-configurator) can
-be used as a translation layer between the ingress interface and the haproxy-route interface,
+be used as a translation layer between the ingress interface and the `haproxy-route` interface,
 but it also works to proxy backends external to Juju.
 
 In this tutorial we are going to run a local Python application hosting a web server. Run the following command:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ juju deploy haproxy --channel=2.8/edge --base=ubuntu@24.04
 ```
 
 ## Configure TLS
-HAproxy enforces HTTPS when using the `ingress` integration. To set up the TLS for the HAProxy charm, deploy the `self-signed-certificates` charm as the `cert` application and integrate with the HAProxy charm.
+HAProxy enforces HTTPS when using the `ingress` integration. To set up the TLS for the HAProxy charm, deploy the `self-signed-certificates` charm as the `cert` application and integrate with the HAProxy charm.
 ```
 juju deploy self-signed-certificates cert
 juju integrate haproxy cert

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,7 +125,7 @@ If successful, the terminal will respond with `ok!`.
 
 Well done! You've successfully completed the HAProxy tutorial.
 
-Kill the backgroup Python web server with:
+Kill the background Python web server with:
 ```
 kill $!
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,7 @@ The [Ingress configurator charm](https://charmhub.io/ingress-configurator) can
 be used as a translation layer between the ingress interface and the haproxy-route interface,
 but it also works to proxy backends external to Juju.
 
-In this tutorial we are going to run a local Python aplication hosting a web server. Run the following command:
+In this tutorial we are going to run a local Python application hosting a web server. Run the following command:
 ```
 python3 -m http.server 8080 &
 ```


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Because of the current changes to the HAProxy, the tutorial was not working.

Until there is an example of clean machine charm that can integrate with ingress, the proposal of the PR is to fix the tutorial using the ingress-integrator and a local web server. 

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
