### PR TITLE
fix typo

### DIFF
--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -133,7 +133,7 @@ class HAProxyRouteBackend:
         if self.application_data.load_balancing.algorithm == LoadBalancingAlgorithm.COOKIE:
             # The library ensures that if algorithm == cookie
             # then the cookie attribute must be not none
-            return f"hash req.cookie({cast(str, self.application_data.load_balancing.cookie)})"
+            return f"hash req.cook({cast(str, self.application_data.load_balancing.cookie)})"
         return str(self.application_data.load_balancing.algorithm.value)
 
     @property


### PR DESCRIPTION
`req.cook` is the correct fetch method instead of `req.cookie`

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
