### PR TITLE
open TCP ports after reloading

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -328,7 +328,14 @@ class HAProxyCharm(ops.CharmBase):
         self.haproxy_service.reconcile_haproxy_route(
             charm_state, haproxy_route_requirers_information
         )
-        self.unit.set_ports(80, 443)
+        self.unit.set_ports(
+            80,
+            443,
+            *(
+                tcp_endpoint.application_data.port
+                for tcp_endpoint in haproxy_route_requirers_information.tcp_endpoints
+            ),
+        )
         if self.unit.is_leader():
             for backend in haproxy_route_requirers_information.backends:
                 relation = self.model.get_relation(HAPROXY_ROUTE_RELATION, backend.relation_id)


### PR DESCRIPTION
Open requested TCP ports after updating haproxy config

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
