### PR TITLE
feat(docs): Evolve and standardize the documentation workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,12 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  docs-checks:
+    uses: canonical/operator-workflows/.github/workflows/docs.yaml@main
+    secrets: inherit
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,16 @@ __pycache__/
 *.egg-info/
 */*.rock
 .venv/
+
+# BEGIN VALE WORKFLOW IGNORE
+.vale/styles/*
+!.vale/styles/local
+!.vale/styles/config/
+
+.vale/styles/config/*
+!.vale/styles/config/vocabularies/
+
+.vale/styles/config/vocabularies/*
+!.vale/styles/config/vocabularies/local
+# END VALE WORKFLOW IGNORE
+

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,12 @@
+; Copyright 2025 Canonical Ltd.
+; See LICENSE file for licensing details.
+
+StylesPath = .vale/styles
+
+Packages = https://github.com/canonical/platform-engineering-vale-package/releases/download/latest/pfe-vale.zip
+
+Vocab = PFE, local
+
+[*]
+BasedOnStyles = PFE
+

--- a/.vale/styles/config/vocabularies/local/accept.txt
+++ b/.vale/styles/config/vocabularies/local/accept.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/.vale/styles/config/vocabularies/local/accept.txt
+++ b/.vale/styles/config/vocabularies/local/accept.txt
@@ -1,1 +1,2 @@
-placeholder
+databag
+proxied

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,12 @@
 # Contributing
 
-To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
+To make contributions to this charm, you'll need a working [development setup](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/).
 
 You can create an environment for development with `tox`:
 
 ```shell
 tox devenv -e integration
 source venv/bin/activate
-```
-
-## Generating src docs for every commit
-
-Run the following command:
-
-```bash
-chmod +x .git/hooks/pre-commit
 ```
 
 ## Testing

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Top-level Makefile
+# Delegates targets to Makefile.docs
+
+# ==============================================================================
+# Macros
+# ==============================================================================
+
+# Colors
+NO_COLOR=\033[0m
+CYAN_COLOR=\033[0;36m
+YELLOW_COLOR=\033[0;93m
+RED_COLOR=\033[0;91m
+
+msg = @printf '$(CYAN_COLOR)$(1)$(NO_COLOR)\n'
+errmsg = @printf '$(RED_COLOR)Error: $(1)$(NO_COLOR)\n' && exit 1
+
+# ==============================================================================
+# Core
+# ==============================================================================
+
+include Makefile.docs
+
+.PHONY: help 
+help: _list-targets ## Prints all available targets
+
+.PHONY: _list-targets
+_list-targets: ## This collects and prints all targets, ignore internal commands
+	$(call msg,Available targets:)
+	@awk -F'[:#]' '                                               \
+		/^[a-zA-Z0-9._-]+:([^=]|$$)/ {                            \
+			target = $$1;                                         \
+			comment = "";                                         \
+			if (match($$0, /## .*/))                              \
+				comment = substr($$0, RSTART + 3);                \
+			if (target != ".PHONY" && target !~ /^_/ && !seen[target]++) \
+				printf "  make %-20s $(YELLOW_COLOR)# %s$(NO_COLOR)\n", target, comment;    \
+		}' $(MAKEFILE_LIST) | sort
+

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -1,0 +1,75 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Minimal makefile for documentation
+#
+
+# Vale settings
+VALE_DIR ?= .vale
+PRAECEPTA_CONFIG 	?= .vale.ini
+DOCS_FILES 	?= docs/ README.md CONTRIBUTING.md
+
+HAS_VALE			:= $(shell command -v vale;)
+HAS_LYCHEE			:= $(shell command -v lychee;)
+
+# ==============================================================================
+# Docs Targets
+# ==============================================================================
+
+.PHONY: docs-check
+docs-check: vale lychee ## Run all Docs checks
+
+.PHONY: docs-clean
+docs-clean: vale-clean
+
+# ==============================================================================
+# Dependency Check Targets
+# ==============================================================================
+
+.PHONY: .check-vale
+.check-vale:
+ifndef HAS_VALE
+	$(call errmsg,'vale' is not installed. Please install it first) \
+	exit 1;
+endif
+
+.PHONY: .check-lychee
+.check-lychee:
+ifndef HAS_LYCHEE
+	$(call errmsg,'lychee' is not installed. Please install it first) \
+	exit 1;
+endif
+
+
+# ==============================================================================
+# Main Vale Targets
+# ==============================================================================
+
+.PHONY: vale-sync
+vale-sync: ## Download and install external Vale configuration sources
+	$(call msg,--- Syncing Vale styles... ---)
+	@vale sync
+
+.PHONY: vale
+vale: .check-vale vale-sync ## Run Vale checks on docs
+	$(call msg,--- Running Vale checks on "$(DOCS_FILES)"... ---)
+	@vale --config=$(PRAECEPTA_CONFIG) $(DOCS_FILES)
+
+# ==============================================================================
+# Main Lychee Targets
+# ==============================================================================
+
+.PHONY: lychee
+lychee: .check-lychee ## Run Lychee checks on docs
+	$(call msg,--- Running lychee checks on "$(LYCHEE_DOCS_FILES)"... ---)
+	@lychee $(DOCS_FILES)
+
+# ==============================================================================
+# Helper Targets
+# ==============================================================================
+
+.PHONY: vale-clean
+vale-clean:
+	$(call msg,--- Cleaning downloaded packages and ignored files from "$(VALE_DIR)"... ---)
+	@git clean -dfX $(VALE_DIR)
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ The haproxy-operator offers advanced features such as TLS, monitoring and high-a
 1. [How-to guides](how-to)
   1. [Configure a virtual IP on OpenStack](how-to/configure-virtual-ip-on-openstack.md)
   1. [Integrate with non-charm workloads](how-to/integrate-with-non-charm-workload.md)
-  1. [Provide extra configurations for ingress requirer charms](how-to/provide-extra-configurations-for-ingress-requirers.md)
+  1. [Provide extra configurations for ingress requirer charms](how-to/provide-extra-configurations-for-ingress-requirer-charms.md)
 1. [Explanation](explanation)
   1. [High availability](explanation/high-availability.md)    
 1. [Release notes](release-notes)

--- a/docs/release-notes/release-notes-rev216.md
+++ b/docs/release-notes/release-notes-rev216.md
@@ -13,7 +13,7 @@ Main bug fixes:
 * Fixed a typo in the cookie fetch method in the load-balancing algorithm ([PR](https://github.com/canonical/haproxy-operator/pull/179)).
 * Fixed an ambiguous endpoint in an integration test ([PR](https://github.com/canonical/haproxy-operator/pull/129)).
 
-See our [Release policy and schedule](docs/release-notes/landing-page.md).
+See our [Release policy and schedule](landing-page.md).
 
 ## Requirements and compatibility
 
@@ -125,7 +125,7 @@ Relevant links:
 * [PR](https://github.com/canonical/haproxy-operator/pull/164)
 
 
-### Added http-server-close support
+### Added `http-server-close` support
 
 Added the `http-server-close` argument to the HAProxy configuration.
 When this argument is set, it closes the connection after the request.


### PR DESCRIPTION
Applicable ticket: ISD-3255

### Description:

This PR builds upon our team's commitment to high-quality documentation by formalizing and standardizing our style-checking workflow.

It evolves our existing efforts of checking against the Canonical [Documentation Style Guide](https://github.com/canonical/documentation-style-guide) (`praecepta`) into a fully integrated, **`vale-native`** process. This more streamlined approach unlocks powerful new capabilities for the team, including:
* Seamless integration with the official **Vale GitHub Action** for automated checks via a new [docs workflow](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/docs.yaml)
* Simple and consistent **`make` targets** for reliable local validation, in line with CI validation.
* The ability to use **IDE extensions** for real-time feedback while writing.

---
### Key Changes

* **CI Automation:**
    * Leveraging our new [docs workflow](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/docs.yaml) to run on every pull request to:
        * Lint all documentation using **Vale**.
        * Check for **broken links**.

* **Layered Vale Configuration:**
    * **Project-Level:** A local `.vale.ini` and `accept.txt` allow for project-specific vocabulary and rule overrides.
    * **Team-Level:** The configuration inherits from our new central [platform-engineering-vale](https://github.com/canonical/platform-engineering-vale-package) package, allowing us to manage team-wide vocabulary and rules in one place.
    * **Company-Level:** The team package is configured to enherit the official Canonical [Documentation Style Guide](https://github.com/canonical/documentation-style-guide) (`praecepta`), ensuring we stay aligned with broader company standards.

* **Improved Local Experience:**
    * A new `Makefile` and `Makefile.docs` provide simple targets for authors to validate their work locally before pushing.
    * Running `make vale`, `make lychee` or `make docs-check` locally is now **identical** to the checks run in CI, eliminating surprises.

### Interested in adding this workflow to a project?

You can add this entire standardized workflow to your own repository with a single command.

First, ensure you are in the root of your project on a **new branch** (not `main`), then run:

```bash
bash <(curl -sSL "https://raw.githubusercontent.com/srbouffard/vale-workflow-template/main/bootstrap.sh?$(date +%s)")
```

The script is interactive and will guide you through the setup.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
Either discourse-gatekeeper will update the documentation on Charmhub, or I will upon approval of this PR.
There are no user-relevant changes in this PR beyond some minor documentation changes, so I didn't update the changelog.