### PR TITLE
chore(deps): Upgrade haproxy apt package

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-10-08
+
+- Upgrading HAproxy apt package to `2.8.5-1ubuntu3.4`.
+
 ## 2025-09-23
 
 - Add documentation for security practices.

--- a/src/haproxy.py
+++ b/src/haproxy.py
@@ -22,7 +22,7 @@ from state.haproxy_route import HaproxyRouteRequirersInformation
 from state.ingress import IngressRequirersInformation
 from state.ingress_per_unit import IngressPerUnitRequirersInformation
 
-APT_PACKAGE_VERSION = "2.8.5-1ubuntu3.3"
+APT_PACKAGE_VERSION = "2.8.5-1ubuntu3.4"
 APT_PACKAGE_NAME = "haproxy"
 HAPROXY_CONFIG_DIR = Path("/etc/haproxy")
 HAPROXY_CONFIG = Path(HAPROXY_CONFIG_DIR / "haproxy.cfg")


### PR DESCRIPTION
### Overview

The current Haproxy apt package pinned in the charm is not available anymore in the Ubuntu repository. This PR updates HAproxy to the version available.

### Rationale

The `install` hook is failing because the `2.8.5-1ubuntu3.4` is not available anymore. This PR fixes the issue.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation for charmhub is updated
- [ ] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
