### PR TITLE
fix handling of haproxy-route-tcp requirer data

### DIFF
--- a/src/state/haproxy_route_tcp.py
+++ b/src/state/haproxy_route_tcp.py
@@ -87,12 +87,16 @@ class HAProxyRouteTcpEndpoint(HaproxyRouteTcpRequirerData):
             list[HaproxyRouteTcpServer]: List of configured backend servers.
         """
         servers = []
-        for i, unit_data in enumerate(self.units_data):
+        backend_addresses = self.application_data.hosts
+        if not backend_addresses:
+            backend_addresses = [unit_data.address for unit_data in self.units_data]
+
+        for i, address in enumerate(backend_addresses):
             servers.append(
                 HaproxyRouteTcpServer(
                     server_name=f"{self.application}-{i}",
                     port=cast(int, self.application_data.backend_port),
-                    address=unit_data.address,
+                    address=address,
                     check=self.application_data.check,
                     maxconn=self.application_data.server_maxconn,
                 )

--- a/src/state/tls.py
+++ b/src/state/tls.py
@@ -134,6 +134,6 @@ class TLSInformation:
         if (
             tls_requirer_integration is None
             or tls_requirer_integration.data.get(charm.app) is None
-        ):
+        ) and not allow_no_certificates:
             logger.error("Relation or relation data not ready.")
             raise TLSNotReadyError("Certificates relation or relation data not ready.")


### PR DESCRIPTION
haproxy was incorrectly handling the haproxy-route-tcp relation data

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
