### PR TITLE
update terraform module to support keepalived, update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ __pycache__/
 # END VALE WORKFLOW IGNORE
 
 **/*.snap
+terraform/**/.terraform*
+terraform/**/.tfvars
+terraform/**/*.tfstate*

--- a/docs/release-notes/artifacts/pr0243.yaml
+++ b/docs/release-notes/artifacts/pr0243.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+changes:
+  - title:  update terraform module to support keepalived, update docs.
+    author: tphan025
+    type: minor
+    description: |
+      Update TF module to provide support for keepalived,
+        add validation rules to ensure mutual exclusivity between the 2 options.
+    urls:
+      pr: https://github.com/canonical/haproxy-operator/pull/243
+      related_doc:
+      related_issue:
+    visibility: public
+    highlight: false

--- a/terraform/charm/README.md
+++ b/terraform/charm/README.md
@@ -21,7 +21,9 @@ No modules.
 |------|------|
 | [juju_application.hacluster](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.haproxy](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+| [juju_application.keepalived](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_integration.ha](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.keepalived](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
 
 ## Inputs
 
@@ -36,10 +38,15 @@ No modules.
 | <a name="input_hacluster_charm_channel"></a> [hacluster\_charm\_channel](#input\_hacluster\_charm\_channel) | Channel of the hacluster charm. | `string` | `"2.4/edge"` | no |
 | <a name="input_hacluster_charm_revision"></a> [hacluster\_charm\_revision](#input\_hacluster\_charm\_revision) | Revision of the hacluster charm. | `number` | `null` | no |
 | <a name="input_hacluster_config"></a> [hacluster\_config](#input\_hacluster\_config) | Hacluster charm config. | `map(string)` | `{}` | no |
-| <a name="input_model"></a> [model](#input\_model) | Name of the juju model. | `string` | `null` | no |
+| <a name="input_keepalived_app_name"></a> [keepalived\_app\_name](#input\_keepalived\_app\_name) | Application name of the keepalived charm. | `string` | `"keepalived"` | no |
+| <a name="input_keepalived_charm_channel"></a> [keepalived\_charm\_channel](#input\_keepalived\_charm\_channel) | Channel of the keepalived charm. | `string` | `"latest/edge"` | no |
+| <a name="input_keepalived_charm_revision"></a> [keepalived\_charm\_revision](#input\_keepalived\_charm\_revision) | Revision of the keepalived charm. | `number` | `null` | no |
+| <a name="input_keepalived_config"></a> [keepalived\_config](#input\_keepalived\_config) | Keepalived charm config. | `map(string)` | `{}` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | ID of the Juju model to deploy to. | `string` | `null` | no |
 | <a name="input_revision"></a> [revision](#input\_revision) | Revision of the haproxy charm. | `number` | `null` | no |
 | <a name="input_units"></a> [units](#input\_units) | Number of haproxy units. If hacluster is enabled, it is recommended to use a value > 3 to ensure a quorum. | `number` | `1` | no |
 | <a name="input_use_hacluster"></a> [use\_hacluster](#input\_use\_hacluster) | Whether to use hacluster for active/passive. | `bool` | `false` | no |
+| <a name="input_use_keepalived"></a> [use\_keepalived](#input\_use\_keepalived) | Whether to use keepalived for active/passive. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -12,7 +12,7 @@ terraform {
 
 resource "juju_application" "haproxy" {
   name  = var.app_name
-  model = var.model
+  model_uuid = var.model_uuid
   units = var.units
 
   charm {
@@ -27,10 +27,41 @@ resource "juju_application" "haproxy" {
   expose {}
 }
 
+resource "juju_application" "keepalived" {
+  count = var.use_keepalived ? 1 : 0
+  name  = var.keepalived_app_name
+  model_uuid = var.model_uuid
+  units = 1
+
+  charm {
+    name     = "keepalived"
+    revision = var.keepalived_charm_revision
+    channel  = var.keepalived_charm_channel
+    base     = var.base
+  }
+
+  config = var.keepalived_config
+}
+
+resource "juju_integration" "keepalived" {
+  count = var.use_keepalived ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.haproxy.name
+    endpoint = "juju-info"
+  }
+
+  application {
+    name     = juju_application.keepalived[0].name
+    endpoint = "juju-info"
+  }
+}
+
 resource "juju_application" "hacluster" {
   count = var.use_hacluster ? 1 : 0
   name  = var.hacluster_app_name
-  model = var.model
+  model_uuid = var.model_uuid
   units = 1
 
   charm {
@@ -45,7 +76,7 @@ resource "juju_application" "hacluster" {
 
 resource "juju_integration" "ha" {
   count = var.use_hacluster ? 1 : 0
-  model = var.model
+  model_uuid = var.model_uuid
 
   application {
     name     = juju_application.haproxy.name

--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -25,8 +25,8 @@ variable "constraints" {
   default     = "arch=amd64"
 }
 
-variable "model" {
-  description = "Name of the juju model."
+variable "model_uuid" {
+  description = "ID of the Juju model to deploy to."
   type        = string
   default     = null
 }
@@ -49,11 +49,22 @@ variable "base" {
   default     = "ubuntu@24.04"
 }
 
-# hacluster
+# HA
 variable "use_hacluster" {
   description = "Whether to use hacluster for active/passive."
   type        = bool
   default     = false
+}
+
+variable "use_keepalived" {
+  description = "Whether to use keepalived for active/passive."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = (!var.use_hacluster || !var.use_keepalived)
+    error_message = "use_hacluster and use_keepalived cannot both be set."
+  }
 }
 
 variable "hacluster_app_name" {
@@ -76,6 +87,30 @@ variable "hacluster_charm_channel" {
 
 variable "hacluster_config" {
   description = "Hacluster charm config."
+  type        = map(string)
+  default     = {}
+}
+
+variable "keepalived_app_name" {
+  description = "Application name of the keepalived charm."
+  type        = string
+  default     = "keepalived"
+}
+
+variable "keepalived_charm_revision" {
+  description = "Revision of the keepalived charm."
+  type        = number
+  default     = null
+}
+
+variable "keepalived_charm_channel" {
+  description = "Channel of the keepalived charm."
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "keepalived_config" {
+  description = "Keepalived charm config."
   type        = map(string)
   default     = {}
 }

--- a/terraform/product/README.md
+++ b/terraform/product/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 0.19.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.0.0 |
 
 ## Modules
 
@@ -23,16 +23,19 @@
 |------|------|
 | [juju_application.grafana_agent](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_integration.grafana_agent](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
-| [juju_model.haproxy](https://registry.terraform.io/providers/juju/juju/latest/docs/data-sources/model) | data source |
+| [juju_model.model](https://registry.terraform.io/providers/juju/juju/latest/docs/data-sources/model) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_grafana_agent"></a> [grafana\_agent](#input\_grafana\_agent) | n/a | <pre>object({<br/>    channel  = optional(string, "latest/stable")<br/>    config   = optional(map(string), {})<br/>    revision = optional(number, null)<br/>  })</pre> | `{}` | no |
-| <a name="input_hacluster"></a> [hacluster](#input\_hacluster) | n/a | <pre>object({<br/>    channel  = optional(string, "2.4/edge")<br/>    config   = optional(map(string), {})<br/>    revision = optional(number, null)<br/>  })</pre> | `{}` | no |
+| <a name="input_grafana_agent"></a> [grafana\_agent](#input\_grafana\_agent) | n/a | <pre>object({<br/>    channel  = optional(string, "2/stable")<br/>    config   = optional(map(string), {})<br/>    revision = optional(number, null)<br/>  })</pre> | `{}` | no |
+| <a name="input_hacluster"></a> [hacluster](#input\_hacluster) | n/a | <pre>object({<br/>    channel  = optional(string, "2.4/edge")<br/>    config   = optional(map(string), {})<br/>    revision = optional(number, null)<br/>  })</pre> | `null` | no |
 | <a name="input_haproxy"></a> [haproxy](#input\_haproxy) | n/a | <pre>object({<br/>    app_name    = optional(string, "haproxy")<br/>    channel     = optional(string, "2.8/edge")<br/>    config      = optional(map(string), {})<br/>    constraints = optional(string, "arch=amd64")<br/>    revision    = optional(number)<br/>    base        = optional(string, "ubuntu@24.04")<br/>    units       = optional(number, 1)<br/>  })</pre> | `{}` | no |
-| <a name="input_model"></a> [model](#input\_model) | Reference to the Juju model to deploy application to. | `string` | n/a | yes |
+| <a name="input_keepalived"></a> [keepalived](#input\_keepalived) | n/a | <pre>object({<br/>    channel  = optional(string, "latest/edge")<br/>    config   = optional(map(string), {})<br/>    revision = optional(number, null)<br/>  })</pre> | `null` | no |
+| <a name="input_model"></a> [model](#input\_model) | Reference to the Juju model to deploy application to. | `string` | `""` | no |
+| <a name="input_model_owner"></a> [model\_owner](#input\_model\_owner) | ID of the model owner, used in conjunction with model name. | `string` | `"admin"` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | ID of the model to deploy to, takes priority over model + model\_owner | `string` | `""` | no |
 
 ## Outputs
 

--- a/terraform/product/README.md
+++ b/terraform/product/README.md
@@ -3,13 +3,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.19.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.0.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
 
 ## Modules
 
@@ -23,7 +23,6 @@
 |------|------|
 | [juju_application.grafana_agent](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_integration.grafana_agent](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
-| [juju_model.model](https://registry.terraform.io/providers/juju/juju/latest/docs/data-sources/model) | data source |
 
 ## Inputs
 
@@ -33,8 +32,6 @@
 | <a name="input_hacluster"></a> [hacluster](#input\_hacluster) | n/a | <pre>object({<br/>    channel  = optional(string, "2.4/edge")<br/>    config   = optional(map(string), {})<br/>    revision = optional(number, null)<br/>  })</pre> | `null` | no |
 | <a name="input_haproxy"></a> [haproxy](#input\_haproxy) | n/a | <pre>object({<br/>    app_name    = optional(string, "haproxy")<br/>    channel     = optional(string, "2.8/edge")<br/>    config      = optional(map(string), {})<br/>    constraints = optional(string, "arch=amd64")<br/>    revision    = optional(number)<br/>    base        = optional(string, "ubuntu@24.04")<br/>    units       = optional(number, 1)<br/>  })</pre> | `{}` | no |
 | <a name="input_keepalived"></a> [keepalived](#input\_keepalived) | n/a | <pre>object({<br/>    channel  = optional(string, "latest/edge")<br/>    config   = optional(map(string), {})<br/>    revision = optional(number, null)<br/>  })</pre> | `null` | no |
-| <a name="input_model"></a> [model](#input\_model) | Reference to the Juju model to deploy application to. | `string` | `""` | no |
-| <a name="input_model_owner"></a> [model\_owner](#input\_model\_owner) | ID of the model owner, used in conjunction with model name. | `string` | `"admin"` | no |
 | <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | ID of the model to deploy to, takes priority over model + model\_owner | `string` | `""` | no |
 
 ## Outputs

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -1,16 +1,7 @@
 
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-
-data "juju_model" "model" {
-  # Don't fetch the model if model_uuid is provided
-  count = var.model_uuid != "" ? 0 : 1
-  name  = var.model
-  owner = var.model_owner
-}
-
 locals {
-  model_uuid     = var.model_uuid != "" ? var.model_uuid : element(concat(data.juju_model.model.*.id, tolist([""])), 0)
   use_hacluster  = var.hacluster != null
   use_keepalived = var.keepalived != null
 }
@@ -18,7 +9,7 @@ locals {
 module "haproxy" {
   source = "../charm"
 
-  model_uuid  = local.model_uuid
+  model_uuid  = var.model_uuid
   app_name    = var.haproxy.app_name
   channel     = var.haproxy.channel
   revision    = var.haproxy.revision
@@ -40,7 +31,7 @@ module "haproxy" {
 
 resource "juju_application" "grafana_agent" {
   name       = "grafana-agent"
-  model_uuid = local.model_uuid
+  model_uuid = var.model_uuid
   units      = 1
 
   charm {
@@ -54,7 +45,7 @@ resource "juju_application" "grafana_agent" {
 }
 
 resource "juju_integration" "grafana_agent" {
-  model_uuid = local.model_uuid
+  model_uuid = var.model_uuid
 
   application {
     name     = module.haproxy.app_name

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -1,7 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 variable "model_uuid" {
-  description = "ID of the model to deploy to, takes priority over model + model_owner"
+  description = "ID of the model to deploy to"
   type        = string
   default     = ""
 }

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -6,18 +6,6 @@ variable "model_uuid" {
   default     = ""
 }
 
-variable "model" {
-  description = "Reference to the Juju model to deploy application to."
-  type        = string
-  default     = ""
-}
-
-variable "model_owner" {
-  description = "ID of the model owner, used in conjunction with model name."
-  type        = string
-  default     = "admin"
-}
-
 variable "haproxy" {
   type = object({
     app_name    = optional(string, "haproxy")

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -1,9 +1,21 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
+variable "model_uuid" {
+  description = "ID of the model to deploy to, takes priority over model + model_owner"
+  type        = string
+  default     = ""
+}
 
 variable "model" {
   description = "Reference to the Juju model to deploy application to."
   type        = string
+  default     = ""
+}
+
+variable "model_owner" {
+  description = "ID of the model owner, used in conjunction with model name."
+  type        = string
+  default     = "admin"
 }
 
 variable "haproxy" {
@@ -25,12 +37,25 @@ variable "hacluster" {
     config   = optional(map(string), {})
     revision = optional(number, null)
   })
-  default = {}
+  default = null
+}
+
+variable "keepalived" {
+  type = object({
+    channel  = optional(string, "latest/edge")
+    config   = optional(map(string), {})
+    revision = optional(number, null)
+  })
+  default = null
+  validation {
+    condition     = (var.hacluster == null || var.keepalived == null)
+    error_message = "hacluster and keepalived cannot both be set."
+  }
 }
 
 variable "grafana_agent" {
   type = object({
-    channel  = optional(string, "latest/stable")
+    channel  = optional(string, "2/stable")
     config   = optional(map(string), {})
     revision = optional(number, null)
   })

--- a/terraform/product/versions.tf
+++ b/terraform/product/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.19.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
Update TF module to provide support for keepalived, add validation rules to ensure mutual exclusivity between the 2 options.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
