### PR TITLE
Skip initialization of the TLSInformation state component if `allow_no_certificates` is set to True

### DIFF
--- a/docs/release-notes/artifacts/pr0255.yaml
+++ b/docs/release-notes/artifacts/pr0255.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+changes:
+  - title: Handle optional TLS information in charm and state
+    author: Phan Trung Thanh
+    type: bugfix
+    description: |
+      Allow TLSInformation.from_charm to return None when certificates are not required,
+      and handle this case in the charm code to avoid errors.
+    urls:
+      pr: https://github.com/canonical/haproxy-operator/pull/255
+      related_doc:
+      related_issue:
+    visibility: hidden
+    highlight: false

--- a/docs/release-notes/artifacts/pr0255.yaml
+++ b/docs/release-notes/artifacts/pr0255.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 changes:
   - title: Handle optional TLS information in charm and state
-    author: Phan Trung Thanh
+    author: tphan025
     type: bugfix
     description: |
       Allow TLSInformation.from_charm to return None when certificates are not required,

--- a/src/charm.py
+++ b/src/charm.py
@@ -266,9 +266,9 @@ class HAProxyCharm(ops.CharmBase):
                 self._configure_haproxy_route(charm_state)
             case _:
                 # Reconcile certificates in case the certificates relation is present
-                if (
+                if self.model.get_relation(TLS_CERT_RELATION) and (
                     tls_information := TLSInformation.from_charm(self, self.certificates)
-                ) and self.model.get_relation(TLS_CERT_RELATION):
+                ):
                     self._tls.certificate_available(tls_information)
 
                 self.unit.set_ports(80)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -288,6 +288,7 @@ def test_tls_allow_no_certificate():
     tls_information = TLSInformation.from_charm(
         charm_mock, certificate_requirer_mock, allow_no_certificates=True
     )
+    assert tls_information is not None
     assert not tls_information.hostnames
     assert tls_information.private_key == "mock private key"
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -276,21 +276,11 @@ def test_tls_allow_no_certificate():
     assert: The state passes validation even though no certificate is found.
     """
     charm_mock = MagicMock(spec=ops.CharmBase)
-    relation_mock = MagicMock(autospec=True)
-    relation_mock.data.get = MagicMock(return_value={})
-    charm_mock.model.get_relation = MagicMock(return_value=relation_mock)
     certificate_requirer_mock = MagicMock(spec=TLSCertificatesRequiresV4)
-    certificate_requirer_mock.get_assigned_certificates = MagicMock(
-        return_value=([], "mock private key")
-    )
-    certificate_requirer_mock.relationship_name = "certificates"
-    certificate_requirer_mock.certificate_requests = []
     tls_information = TLSInformation.from_charm(
         charm_mock, certificate_requirer_mock, allow_no_certificates=True
     )
-    assert tls_information is not None
-    assert not tls_information.hostnames
-    assert tls_information.private_key == "mock private key"
+    assert tls_information is None
 
 
 def test_haproxy_route_tcp_endpoint(


### PR DESCRIPTION
return None in `TLSInformation.from_charm` if `allow_no_certificates` is true, update charm code and tests.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
