### PR TITLE
Support header rewrite expressions and remove restrictions in library

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ frontend.
 HAPROXY_HOSTNAME="haproxy.internal"
 LOCAL_IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
 juju deploy ingress-configurator  --channel=edge --config hostname=$HAPROXY_HOSTNAME --config backend-addresses=$LOCAL_IPADDR --config backend-ports=8080
-juju integrate ingress-configurator haproxy
+juju integrate ingress-configurator:haproxy-route haproxy
 ```
 
 Let's check that the request has been properly proxied to the backend service. 

--- a/docs/release-notes/artifacts/pr0257.yaml
+++ b/docs/release-notes/artifacts/pr0257.yaml
@@ -4,8 +4,8 @@ changes:
     author: javierdelapuente
     type: minor
     description: |
-      Currently some valid character are not allowed for expressions in the
-      haproxy_route relation. Only restrict the newline character.
+      Currently some valid characters are not allowed for expressions in the
+      `haproxy_route` relation. Now only the newline character is restricted.
     urls:
       pr: https://github.com/canonical/haproxy-operator/pull/257
       related_doc:

--- a/docs/release-notes/artifacts/pr0257.yaml
+++ b/docs/release-notes/artifacts/pr0257.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 changes:
-  - title: Remove haproxy_route restriction for expressions
+  - title: Remove `haproxy_route` restriction for expressions
     author: javierdelapuente
     type: minor
     description: |

--- a/docs/release-notes/artifacts/pr0257.yaml
+++ b/docs/release-notes/artifacts/pr0257.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+changes:
+  - title: Remove haproxy_route restriction for expressions
+    author: javierdelapuente
+    type: minor
+    description: |
+      Currently some valid character are not allowed for expressions in the
+      haproxy_route relation. Only restrict the newline character.
+    urls:
+      pr: https://github.com/canonical/haproxy-operator/pull/257
+      related_doc:
+      related_issue:
+    visibility: public
+    highlight: false
+

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -166,7 +166,7 @@ def value_contains_invalid_characters(
     """Validate if value contains invalid config characters.
 
     Args:
-        invalid_characters: List of invalid characters.
+        invalid_characters: String with the list of invalid characters.
         value: The value to validate.
 
     Raises:

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -151,7 +151,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
@@ -509,7 +509,7 @@ class RewriteConfiguration(BaseModel):
     method: HaproxyRewriteMethod = Field(
         description="Which rewrite method to apply.One of set-path, set-query, set-header."
     )
-    expression: VALIDSTR = Field(description="Regular expression to use with the rewrite method.")
+    expression: str = Field(description="Regular expression to use with the rewrite method.")
     header: Optional[VALIDSTR] = Field(
         description="The name of the header to rewrite.", default=None
     )

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -123,6 +123,7 @@ class SomeCharm(CharmBase):
 import json
 import logging
 from enum import Enum
+from functools import partial
 from typing import Annotated, Any, Literal, MutableMapping, Optional, cast
 
 from ops import CharmBase, ModelError, RelationBrokenEvent
@@ -156,12 +157,16 @@ LIBPATCH = 10
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
 HAPROXY_CONFIG_INVALID_CHARACTERS = "\n\t#\\'\"\r$ "
+HAPROXY_EXPR_INVALID_CHARACTERS = "\n"
 
 
-def value_contains_invalid_characters(value: Optional[str]) -> Optional[str]:
-    """Validate if value contains invalid haproxy config characters.
+def value_contains_invalid_characters(
+    invalid_characters: str, value: Optional[str]
+) -> Optional[str]:
+    """Validate if value contains invalid config characters.
 
     Args:
+        invalid_characters: List of invalid characters.
         value: The value to validate.
 
     Raises:
@@ -173,12 +178,19 @@ def value_contains_invalid_characters(value: Optional[str]) -> Optional[str]:
     if value is None:
         return value
 
-    if [char for char in value if char in HAPROXY_CONFIG_INVALID_CHARACTERS]:
+    if [char for char in value if char in invalid_characters]:
         raise ValueError(f"Relation data contains invalid character(s) {value}")
     return value
 
 
-VALIDSTR = Annotated[str, BeforeValidator(value_contains_invalid_characters)]
+VALIDSTR = Annotated[
+    str,
+    BeforeValidator(partial(value_contains_invalid_characters, HAPROXY_CONFIG_INVALID_CHARACTERS)),
+]
+VALIDEXPRSTR = Annotated[
+    str,
+    BeforeValidator(partial(value_contains_invalid_characters, HAPROXY_EXPR_INVALID_CHARACTERS)),
+]
 
 
 class DataValidationError(Exception):
@@ -509,7 +521,9 @@ class RewriteConfiguration(BaseModel):
     method: HaproxyRewriteMethod = Field(
         description="Which rewrite method to apply.One of set-path, set-query, set-header."
     )
-    expression: str = Field(description="Regular expression to use with the rewrite method.")
+    expression: VALIDEXPRSTR = Field(
+        description="Regular expression to use with the rewrite method."
+    )
     header: Optional[VALIDSTR] = Field(
         description="The name of the header to rewrite.", default=None
     )

--- a/src/state/haproxy_route.py
+++ b/src/state/haproxy_route.py
@@ -172,7 +172,7 @@ class HAProxyRouteBackend:
         for rewrite in self.application_data.rewrites:
             if rewrite.method == HaproxyRewriteMethod.SET_HEADER:
                 rewrite_configurations.append(
-                    f"{rewrite.method!s} {rewrite.header} {rewrite.expression}"
+                    f"{rewrite.method.value!s} {rewrite.header} {rewrite.expression}"
                 )
                 continue
             rewrite_configurations.append(f"{rewrite.method.value!s} {rewrite.expression}")

--- a/tests/unit/test_haproxy_route.py
+++ b/tests/unit/test_haproxy_route.py
@@ -10,11 +10,14 @@ from unittest.mock import MagicMock
 import pytest
 from charms.haproxy.v0.haproxy_route_tcp import HaproxyRouteTcpRequirersData
 from charms.haproxy.v1.haproxy_route import (
+    HaproxyRewriteMethod,
     HaproxyRouteRequirerData,
     HaproxyRouteRequirersData,
     RequirerApplicationData,
     RequirerUnitData,
+    RewriteConfiguration,
 )
+from pydantic import ValidationError
 
 from state.haproxy_route import HaproxyRouteRequirersInformation
 
@@ -120,3 +123,16 @@ def test_haproxy_route_requirer_information(
     assert haproxy_route_information.acls_for_allow_http == [
         "{ req.hdr(Host) -m str example.com } { path_beg -i /path } !{ path_beg -i /private }"
     ]
+
+
+def test_rewrite_expression_does_not_allow_newline():
+    """
+    act: Create a RewriteConfiguration with an expression containing a newline character.
+    assert: ValidationError is raised
+    """
+    with pytest.raises(ValidationError) as exc:
+        RewriteConfiguration(
+            method=HaproxyRewriteMethod.SET_PATH,
+            expression="data\ninjection data",
+        )
+    assert "invalid character" in str(exc)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Currently for rewrite expressions, many characters are not allowed, like ' and ". These characters are very useful and recommended in expressions like [regsub](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#7-regsub).

Also minor fix about header rewrite templating in HAProxy configuration file.

Related to https://github.com/canonical/ingress-configurator-operator/pull/45. 

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
