### PR TITLE
Change schedule and group all non major updates

### DIFF
--- a/docs/release-notes/artifacts/pr0262.yaml
+++ b/docs/release-notes/artifacts/pr0262.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+changes:
+  - title:  run renovate only twice a month
+    author: javierdelapuente
+    type: minor
+    description: |
+      Run renovate only twice a month except for vulnerability alerts.
+      Also use allNonMajor.
+    urls:
+      pr: https://github.com/canonical/haproxy-operator/pull/262
+      related_doc:
+      related_issue:
+    visibility: internal
+    highlight: false

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "automerge": true,
   "extends": [
-    "config:base"
+    "config:base",
+    "group:allNonMajor"
   ],
   "packageRules": [
     {
@@ -38,5 +39,11 @@
       "matchStringsStrategy": "any",
       "versioningTemplate": "ubuntu"
     }
-  ]
+  ],
+  "schedule": [
+    "* 0-5 1,15 * *"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Renovate is noisy in this repository. Update it to group all non major revisions and run only every 15 days (except for security issues).

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
