### PR TITLE
Update workflow for change artifact compliance

### DIFF
--- a/.github/pull_request_template.yaml
+++ b/.github/pull_request_template.yaml
@@ -26,7 +26,7 @@ Applicable spec: <link>
 - [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
 - [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
 - [ ] The documentation for charmhub is updated
-- [ ] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
+- [ ] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
 - [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
 - [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
 

--- a/.github/workflows/check_release_notes_artifact.yaml
+++ b/.github/workflows/check_release_notes_artifact.yaml
@@ -1,38 +1,11 @@
-name: Check for release notes artifact
+name: 'Check for release notes artifact'
 
 on:
   pull_request:
 
 jobs:
-  check-release-note-artifact:
-    # run only for PRs not opened by a bot
-    if: ${{ github.event.pull_request.user.type != 'Bot' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PR
-        uses: actions/checkout@v6.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Fail if no new artifact in docs/release-notes/artifacts
-        run: |
-          set -euo pipefail
-
-          BASE_SHA=${{ github.event.pull_request.base.sha }}
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-
-          # List added files between base and head
-          ADDED_FILES=$(git diff --name-status "${BASE_SHA}" "${HEAD_SHA}" | awk '$1 == "A" { print $2 }' || true)
-
-          # Filter for YAML files under docs/release-notes/artifacts/
-          MATCHING=$(printf "%s\n" "${ADDED_FILES}" | grep -E '^docs/release-notes/artifacts/.*\.yaml$' || true)
-
-          if [ -z "${MATCHING}" ]; then
-            echo "ERROR: No new YAML file added under docs/release-notes/artifacts/ in this PR."
-            echo "Please add a change artifact file that summarizes your pull request under docs/release-notes/artifacts/."
-            exit 1
-          fi
-
-          echo "Found the following release-notes artifact(s) in this PR:"
-          printf "%s\n" "${MATCHING}"
-
+  check-change-artifacts:
+    uses: canonical/release-notes-automation/.github/workflows/pr-compliance.yml@main
+    secrets: inherit
+    with:
+      change-artifact-dir: docs/release-notes/artifacts

--- a/.github/workflows/check_release_notes_artifact.yaml
+++ b/.github/workflows/check_release_notes_artifact.yaml
@@ -9,3 +9,4 @@ jobs:
     secrets: inherit
     with:
       change-artifact-dir: docs/release-notes/artifacts
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-11-27
+
+- Updated the change artifact compliance workflow with an opt-out ability.
+
 ## 2025-11-24
 
 - Added HTTP/2 support to HAProxy for both frontend and backend configurations.


### PR DESCRIPTION
Applicable spec: ISD263

### Overview

Update the compliance workflow `.github/workflows/check_release_notes_artifact.yaml` to use [`pr-compliance.yml`](https://github.com/canonical/release-notes-automation/blob/main/.github/workflows/pr-compliance.yml).

### Rationale

This updated workflow improves the compliance in two ways:
1. Ability to opt out: By tagging the PR with the `artifact opt out` label, you can skip the workflow for PRs where a change artifact is not necessary.
2. Ability to edit preexisting artifacts: For feature development over multiple PRs, you can now edit an existing artifact, and the workflow will consider this a success.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [n/a] The documentation for charmhub is updated
- [n/a] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
There are no documentation changes in this PR. A change artifact is not required for this PR.
