### PR TITLE
Update haproxy-spoe-auth charm template to fix some syntax errors

### DIFF
--- a/docs/release-notes/artifacts/pr0268.yaml
+++ b/docs/release-notes/artifacts/pr0268.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 changes:
-  - title: Update haproxy-spoe-auth configuration template and event hooks
+  - title: Updated haproxy-spoe-auth configuration template and event hooks
     author: tphan025
     type: minor
     description: |

--- a/docs/release-notes/artifacts/pr0268.yaml
+++ b/docs/release-notes/artifacts/pr0268.yaml
@@ -1,0 +1,16 @@
+# --- Release notes change artifact ----
+
+schema_version: 1
+changes:
+  - title: Update haproxy-spoe-auth configuration template and event hooks
+    author: tphan025
+    type: minor
+    description: |
+      Fix configuration template keys to match the expected YAML
+        structure and add missing relation event observers for OAuth integration.
+    urls: 
+      pr: https://github.com/canonical/haproxy-operator/pull/268
+      related_doc: 
+      related_issue: 
+    visibility: hidden
+    highlight: false

--- a/docs/release-notes/artifacts/pr0268.yaml
+++ b/docs/release-notes/artifacts/pr0268.yaml
@@ -6,7 +6,7 @@ changes:
     author: tphan025
     type: minor
     description: |
-      Fix configuration template keys to match the expected YAML
+      Fixed configuration template keys to match the expected YAML
         structure and add missing relation event observers for OAuth integration.
     urls: 
       pr: https://github.com/canonical/haproxy-operator/pull/268

--- a/haproxy-spoe-auth-operator/src/charm.py
+++ b/haproxy-spoe-auth-operator/src/charm.py
@@ -48,7 +48,6 @@ class HaproxySpoeAuthCharm(ops.CharmBase):
 
         self.framework.observe(self.on.install, self._reconcile)
         self.framework.observe(self.on.config_changed, self._reconcile)
-        self.framework.observe(self.on[OAUTH_RELATION].relation_created, self._reconcile)
         self.framework.observe(self.on[OAUTH_RELATION].relation_changed, self._reconcile)
         self.framework.observe(self._oauth.on.oauth_info_changed, self._reconcile)
         self.framework.observe(self._oauth.on.oauth_info_removed, self._reconcile)

--- a/haproxy-spoe-auth-operator/src/charm.py
+++ b/haproxy-spoe-auth-operator/src/charm.py
@@ -48,6 +48,8 @@ class HaproxySpoeAuthCharm(ops.CharmBase):
 
         self.framework.observe(self.on.install, self._reconcile)
         self.framework.observe(self.on.config_changed, self._reconcile)
+        self.framework.observe(self.on[OAUTH_RELATION].relation_created, self._reconcile)
+        self.framework.observe(self.on[OAUTH_RELATION].relation_changed, self._reconcile)
         self.framework.observe(self._oauth.on.oauth_info_changed, self._reconcile)
         self.framework.observe(self._oauth.on.oauth_info_removed, self._reconcile)
 

--- a/haproxy-spoe-auth-operator/templates/config.yaml.j2
+++ b/haproxy-spoe-auth-operator/templates/config.yaml.j2
@@ -29,7 +29,7 @@ oidc:
   # The secret used to encrypt the cookie in order to guarantee the privacy of the data in case of leak
   encryption_secret: {{ encryption_secret }}
 
-oauth:
+clients:
   {{ hostname }}:
     client_id: {{ client_id }}
     client_secret: {{ client_secret }}

--- a/haproxy-spoe-auth-operator/templates/config.yaml.j2
+++ b/haproxy-spoe-auth-operator/templates/config.yaml.j2
@@ -29,8 +29,8 @@ oidc:
   # The secret used to encrypt the cookie in order to guarantee the privacy of the data in case of leak
   encryption_secret: {{ encryption_secret }}
 
-clients:
-  {{ hostname }}:
-    client_id: {{ client_id }}
-    client_secret: {{ client_secret }}
-    redirect_url: https://{{ hostname }}{{ oidc_callback_path }}
+  clients:
+    {{ hostname }}:
+      client_id: {{ client_id }}
+      client_secret: {{ client_secret }}
+      redirect_url: https://{{ hostname }}{{ oidc_callback_path }}

--- a/haproxy-spoe-auth-operator/templates/config.yaml.j2
+++ b/haproxy-spoe-auth-operator/templates/config.yaml.j2
@@ -1,6 +1,6 @@
 # HAProxy SPOE Auth Configuration
-spoe:
-  address: 0.0.0.0:{{ spop_port }}
+server:
+  addr: 0.0.0.0:{{ spop_port }}
 
 oidc:
   # The URL to the OpenID Connect provider. This is the URL hosting the discovery endpoint


### PR DESCRIPTION
Update haproxy-spoe-auth charm template to fix some syntax errors.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
