### PR TITLE
run reset-failed everytime we manually restart the haproxy-spoe-auth service

### DIFF
--- a/haproxy-spoe-auth-operator/src/haproxy_spoe_auth_service.py
+++ b/haproxy-spoe-auth-operator/src/haproxy_spoe_auth_service.py
@@ -4,6 +4,10 @@
 """The haproxy-spoe-auth service module."""
 
 import logging
+
+# We silence this rule because subprocess call is only for
+# resetting the service restart counter and no user input is parsed
+import subprocess  # nosec B404
 from pathlib import Path
 
 from charmlibs import snap
@@ -20,6 +24,7 @@ OIDC_HEALTHCHECK_PATH = "/health"
 OIDC_LOGOUT_PATH = "/oauth2/logout"
 SNAP_CHANNEL = "latest/edge"
 SNAP_NAME = "haproxy-spoe-auth"
+SNAP_SERVICE_NAME = "snap.haproxy-spoe-auth.haproxy-spoe-auth.service"
 SPOP_PORT = 8081
 
 logger = logging.getLogger(__name__)
@@ -51,7 +56,6 @@ class SpoeAuthService:
         try:
             if not self.haproxy_spoe_auth_snap.present:
                 self.haproxy_spoe_auth_snap.ensure(snap.SnapState.Latest, channel=SNAP_CHANNEL)
-            self.haproxy_spoe_auth_snap.restart(reload=True)
         except snap.SnapError as exc:
             logger.error(
                 "An exception occurred when installing the haproxy-spoe-auth snap: %s",
@@ -72,8 +76,12 @@ class SpoeAuthService:
         try:
             self._render_config(charm_state, oauth_information)
             self.haproxy_spoe_auth_snap.restart(reload=True)
-        except snap.SnapError as exc:
-            raise SpoeAuthServiceConfigError(f"Failed to reconcile service: {exc}") from exc
+            # Ignore bandit rule as this is only used to reset the service restart counter.
+            subprocess.check_call(["/usr/bin/systemctl", "reset-failed", SNAP_SERVICE_NAME])  # nosec B603
+        except (snap.SnapError, subprocess.CalledProcessError) as exc:
+            raise SpoeAuthServiceConfigError(
+                f"Failed to reconcile the haproxy-spoe-auth service: {exc}"
+            ) from exc
 
     def _render_config(self, charm_state: CharmState, oauth_information: OauthInformation) -> None:
         """Render the configuration file.

--- a/haproxy-spoe-auth-operator/src/haproxy_spoe_auth_service.py
+++ b/haproxy-spoe-auth-operator/src/haproxy_spoe_auth_service.py
@@ -7,7 +7,7 @@ import logging
 
 # We silence this rule because subprocess call is only for
 # resetting the service restart counter and no user input is parsed
-import subprocess  # nosec B404
+import subprocess  # nosec blacklist
 from pathlib import Path
 
 from charmlibs import snap
@@ -77,7 +77,7 @@ class SpoeAuthService:
             self._render_config(charm_state, oauth_information)
             self.haproxy_spoe_auth_snap.restart(reload=True)
             # Ignore bandit rule as this is only used to reset the service restart counter.
-            subprocess.check_call(["/usr/bin/systemctl", "reset-failed", SNAP_SERVICE_NAME])  # nosec B603
+            subprocess.check_call(["/usr/bin/systemctl", "reset-failed", SNAP_SERVICE_NAME])  # nosec subprocess_without_shell_equals_true
         except (snap.SnapError, subprocess.CalledProcessError) as exc:
             raise SpoeAuthServiceConfigError(
                 f"Failed to reconcile the haproxy-spoe-auth service: {exc}"


### PR DESCRIPTION
This is because this snap doesn't support reloading and the systemd service created by snapd uses the default restart limit of 5 every 10 seconds, so it's quite easy to hit the restart limit if events come too quickly, so we do this for "intentional" restarts to not hit the restart limit ( note that this is not done for on-failure restarts so we still have a limit in that case )

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
