### PR TITLE
unpin haproxy apt package

### DIFF
--- a/docs/release-notes/artifacts/pr0276.yaml
+++ b/docs/release-notes/artifacts/pr0276.yaml
@@ -1,0 +1,14 @@
+# --- Release notes change artifact ----
+
+schema_version: 1
+changes:
+  - title: Unpin HAProxy apt package version
+    author: tphan025
+    type: minor
+    description: Unpinned the HAProxy APT package version.
+    urls: 
+      pr: https://github.com/canonical/haproxy-operator/pull/276
+      related_doc: 
+      related_issue: 
+    visibility: public
+    highlight: false

--- a/haproxy-operator/src/haproxy.py
+++ b/haproxy-operator/src/haproxy.py
@@ -22,7 +22,6 @@ from state.haproxy_route import HaproxyRouteRequirersInformation
 from state.ingress import IngressRequirersInformation
 from state.ingress_per_unit import IngressPerUnitRequirersInformation
 
-APT_PACKAGE_VERSION = "2.8.5-1ubuntu3.4"
 APT_PACKAGE_NAME = "haproxy"
 HAPROXY_CONFIG_DIR = Path("/etc/haproxy")
 HAPROXY_CONFIG = Path(HAPROXY_CONFIG_DIR / "haproxy.cfg")
@@ -83,9 +82,7 @@ class HAProxyService:
 
     def install(self) -> None:
         """Install the haproxy apt package."""
-        apt.add_package(
-            package_names=APT_PACKAGE_NAME, version=APT_PACKAGE_VERSION, update_cache=True
-        )
+        apt.add_package(package_names=APT_PACKAGE_NAME, update_cache=True)
         pin_haproxy_package_version()
         render_file(HAPROXY_DHCONFIG, HAPROXY_DH_PARAM, 0o644)
 


### PR DESCRIPTION
After discussing internally we've decided that we'll unpin the version of the haproxy apt package. Initially the idea to pin the package version is to not have the workload updated during a `confiig-changed` event and the updates should be manual via `juju refresh`. However, this has caused more problems than expected since previous versions are also removed when a new version is available.

We've decided therefore to rely on the release process of the base image ( 24.04 ) and unpin the haproxy APT package as we've evaluated that there's likely won't be a risk of drastically changed behavior with an unsupervised version update in the cham hooks.

Fixes #271 #210 

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] A [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
