### PR TITLE
Missing hook in spoe charm

### DIFF
--- a/haproxy-spoe-auth-operator/src/charm.py
+++ b/haproxy-spoe-auth-operator/src/charm.py
@@ -54,6 +54,7 @@ class HaproxySpoeAuthCharm(ops.CharmBase):
         self.framework.observe(self.on[OAUTH_RELATION].relation_changed, self._reconcile)
         self.framework.observe(self._oauth.on.oauth_info_changed, self._reconcile)
         self.framework.observe(self._oauth.on.oauth_info_removed, self._reconcile)
+        self.framework.observe(self.on[SPOE_AUTH_RELATION].relation_changed, self._reconcile)
 
     def _reconcile(self, _: ops.EventBase) -> None:
         """Reconcile the charm state and service configuration."""


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

There is a missing hook in the spoe charm. If a the spoe-auth relation is added after all required config/other relations had already been added, no even will be set and the spoe-auth relation will not be updated not the spoe service triggered.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
