### PR TITLE
HSTS implementation

### DIFF
--- a/docs/release-notes/artifacts/pr0296.yaml
+++ b/docs/release-notes/artifacts/pr0296.yaml
@@ -8,7 +8,7 @@ changes:
     description: |
       Add new config option to the charm enable Strict-Transport-Security response header
       with the default value "max-age=2592000;". This http response header will apply to
-      the the http-route relation for domains without the allow_http attribute.
+      the http-route relation for domains without the allow_http attribute.
     urls:
       pr: https://github.com/canonical/haproxy-operator/pull/296
       related_doc:

--- a/docs/release-notes/artifacts/pr0296.yaml
+++ b/docs/release-notes/artifacts/pr0296.yaml
@@ -1,0 +1,17 @@
+# --- Release notes change artifact ----
+
+schema_version: 1
+changes:
+  - title: Add enable-hsts option to enable Strict-Transport-Security response header.
+    author: javierdelapuente
+    type: minor
+    description: |
+      Add new config option to the charm enable Strict-Transport-Security response header
+      with the default value "max-age=2592000;". This http response header will apply to
+      the the http-route relation for domains without the allow_http attribute.
+    urls:
+      pr: https://github.com/canonical/haproxy-operator/pull/296
+      related_doc:
+      related_issue:
+    visibility: public
+    highlight: false

--- a/haproxy-operator/charmcraft.yaml
+++ b/haproxy-operator/charmcraft.yaml
@@ -93,6 +93,12 @@ config:
     vip:
       type: string
       description: Virtual IP address, used in active-passive ha mode.
+    enable-hsts:
+      default: false
+      type: boolean
+      description: |
+        Send the http response header Strict-Transport-Security for https only domains.
+        The header will be sent with the value "max-age=2592000;".
 
 actions:
   get-certificate:

--- a/haproxy-operator/charmcraft.yaml
+++ b/haproxy-operator/charmcraft.yaml
@@ -97,8 +97,9 @@ config:
       default: false
       type: boolean
       description: |
-        Send the http response header Strict-Transport-Security for https only domains.
-        The header will be sent with the value "max-age=2592000;".
+        Send the http response header Strict-Transport-Security for domains provided
+        through the `haproxy-route` relation without the allow_http attribute.
+        The Strict-Transport-Security header value is "max-age=2592000;".
 
 actions:
   get-certificate:

--- a/haproxy-operator/src/haproxy.py
+++ b/haproxy-operator/src/haproxy.py
@@ -159,6 +159,7 @@ class HAProxyService:
         """
         template_context = {
             "config_global_max_connection": charm_state.global_max_connection,
+            "enable_hsts": charm_state.enable_hsts,
             "backends": haproxy_route_requirers_information.backends,
             "tcp_endpoints": haproxy_route_requirers_information.tcp_endpoints,
             "stick_table_entries": haproxy_route_requirers_information.stick_table_entries,

--- a/haproxy-operator/src/state/charm_state.py
+++ b/haproxy-operator/src/state/charm_state.py
@@ -66,6 +66,7 @@ class CharmState:
     """
 
     mode: ProxyMode
+    enable_hsts: bool
     global_max_connection: int = Field(gt=0, alias="global_max_connection")
 
     @field_validator("global_max_connection")
@@ -187,6 +188,7 @@ class CharmState:
             CharmState: Instance of the charm state component.
         """
         global_max_connection = typing.cast(int, charm.config.get("global-maxconn"))
+        enable_hsts = typing.cast(bool, charm.config.get("enable-hsts"))
         try:
             return cls(
                 mode=cls._validate_state(
@@ -197,6 +199,7 @@ class CharmState:
                     reverseproxy_requirer,
                 ),
                 global_max_connection=global_max_connection,
+                enable_hsts=enable_hsts,
             )
         except ValidationError as exc:
             error_field_str = ",".join(f"{field}" for field in get_invalid_config_fields(exc))

--- a/haproxy-operator/templates/haproxy_route.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route.cfg.j2
@@ -10,7 +10,7 @@ frontend haproxy
 
 {% if enable_hsts %}
     # Add HSTS header for HTTPS connections (only when HTTP is not allowed)
-    http-response set-header Strict-Transport-Security "max-age=2592000;" if { ssl_fc } {% for acl in acls_for_allow_http %} !{{ acl }}{% endfor %}
+    http-response set-header Strict-Transport-Security "max-age=2592000" if { ssl_fc } {% for acl in acls_for_allow_http %} !{{ acl }}{% endfor %}
 {% endif %}
 
 {% for spoe_auth_info in spoe_auth_info_list  %}

--- a/haproxy-operator/templates/haproxy_route.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route.cfg.j2
@@ -8,6 +8,9 @@ frontend haproxy
     # Redirect HTTP to HTTPS
     http-request redirect scheme https unless { ssl_fc } {% for acl in acls_for_allow_http %} || {{ acl }}{% endfor %}
 
+    # Add HSTS header for HTTPS connections (only when HTTP is not allowed)
+    http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;" if { ssl_fc } {% for acl in acls_for_allow_http %} !{{ acl }}{% endfor %}
+
 {% for spoe_auth_info in spoe_auth_info_list  %}
     acl oidc_host_{{ spoe_auth_info.id }} req.hdr(Host) -m str {{ spoe_auth_info.hostname }}
     acl oidc_callback_path_{{ spoe_auth_info.id }} path_beg -i {{ spoe_auth_info.oidc_callback_path }}

--- a/haproxy-operator/templates/haproxy_route.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route.cfg.j2
@@ -8,8 +8,10 @@ frontend haproxy
     # Redirect HTTP to HTTPS
     http-request redirect scheme https unless { ssl_fc } {% for acl in acls_for_allow_http %} || {{ acl }}{% endfor %}
 
+{% if enable_hsts %}
     # Add HSTS header for HTTPS connections (only when HTTP is not allowed)
-    http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;" if { ssl_fc } {% for acl in acls_for_allow_http %} !{{ acl }}{% endfor %}
+    http-response set-header Strict-Transport-Security "max-age=2592000;" if { ssl_fc } {% for acl in acls_for_allow_http %} !{{ acl }}{% endfor %}
+{% endif %}
 
 {% for spoe_auth_info in spoe_auth_info_list  %}
     acl oidc_host_{{ spoe_auth_info.id }} req.hdr(Host) -m str {{ spoe_auth_info.hostname }}

--- a/haproxy-operator/tests/unit/test_hsts.py
+++ b/haproxy-operator/tests/unit/test_hsts.py
@@ -1,0 +1,75 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for HSTS header implementation."""
+
+import pathlib
+import re
+from unittest.mock import ANY, MagicMock
+
+import ops.testing
+import pytest
+
+from charm import HAProxyCharm
+
+from .conftest import build_haproxy_route_relation
+from .helper import RegexMatcher
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_hsts_enabled(monkeypatch: pytest.MonkeyPatch, certificates_integration):
+    """
+    arrange: Prepare a haproxy with haproxy_route.
+    act: trigger relation changed.
+    assert: haproxy.conf will set the strict-transport-security response header but not for the allow_http domain.
+    """
+    render_file_mock = MagicMock()
+    monkeypatch.setattr("haproxy.render_file", render_file_mock)
+    haproxy_route_relation = build_haproxy_route_relation()
+
+    ctx = ops.testing.Context(HAProxyCharm)
+    state = ops.testing.State(relations=[certificates_integration, haproxy_route_relation])
+    out = ctx.run(
+        ctx.on.relation_changed(haproxy_route_relation),
+        state,
+    )
+    assert render_file_mock.call_count == 1
+    render_file_mock.assert_any_call(
+        pathlib.Path("/etc/haproxy/haproxy.cfg"),
+        RegexMatcher(
+            'http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;" if { ssl_fc } \n'
+        ),
+        ANY,
+    )
+    assert out.unit_status.name == ops.testing.ActiveStatus.name
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_hsts_disabled_allow_http(monkeypatch: pytest.MonkeyPatch, certificates_integration):
+    """
+    arrange: Prepare a haproxy with haproxy_route with one allow_http domain.
+    act: trigger relation changed.
+    assert: haproxy.conf will set the strict-transport-security response header but not for the allow_http domain.
+    """
+    render_file_mock = MagicMock()
+    monkeypatch.setattr("haproxy.render_file", render_file_mock)
+    haproxy_route_relation = build_haproxy_route_relation()
+    haproxy_route_relation.remote_app_data["allow_http"] = "true"
+
+    ctx = ops.testing.Context(HAProxyCharm)
+    state = ops.testing.State(relations=[certificates_integration, haproxy_route_relation])
+    out = ctx.run(
+        ctx.on.relation_changed(haproxy_route_relation),
+        state,
+    )
+    assert render_file_mock.call_count == 1
+    render_file_mock.assert_any_call(
+        pathlib.Path("/etc/haproxy/haproxy.cfg"),
+        RegexMatcher(
+            re.escape(
+                'http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;" if { ssl_fc }  !{ req.hdr(Host) -m str haproxy.internal }\n'
+            )
+        ),
+        ANY,
+    )
+    assert out.unit_status.name == ops.testing.ActiveStatus.name

--- a/haproxy-operator/tests/unit/test_hsts.py
+++ b/haproxy-operator/tests/unit/test_hsts.py
@@ -67,7 +67,7 @@ def test_hsts_enabled(monkeypatch: pytest.MonkeyPatch, certificates_integration)
     render_file_mock.assert_any_call(
         pathlib.Path("/etc/haproxy/haproxy.cfg"),
         RegexMatcher(
-            'http-response set-header Strict-Transport-Security "max-age=2592000;" if { ssl_fc } \n'
+            'http-response set-header Strict-Transport-Security "max-age=2592000" if { ssl_fc } \n'
         ),
         ANY,
     )
@@ -100,7 +100,7 @@ def test_hsts_disabled_allow_http(monkeypatch: pytest.MonkeyPatch, certificates_
         pathlib.Path("/etc/haproxy/haproxy.cfg"),
         RegexMatcher(
             re.escape(
-                'http-response set-header Strict-Transport-Security "max-age=2592000;" if { ssl_fc }  !{ req.hdr(Host) -m str haproxy.internal }\n'
+                'http-response set-header Strict-Transport-Security "max-age=2592000" if { ssl_fc }  !{ req.hdr(Host) -m str haproxy.internal }\n'
             )
         ),
         ANY,

--- a/haproxy-operator/tests/unit/test_hsts.py
+++ b/haproxy-operator/tests/unit/test_hsts.py
@@ -17,18 +17,48 @@ from .helper import RegexMatcher
 
 
 @pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
-def test_hsts_enabled(monkeypatch: pytest.MonkeyPatch, certificates_integration):
+def test_hsts_disabled(monkeypatch: pytest.MonkeyPatch, certificates_integration):
     """
     arrange: Prepare a haproxy with haproxy_route.
     act: trigger relation changed.
-    assert: haproxy.conf will set the strict-transport-security response header but not for the allow_http domain.
+    assert: haproxy.conf will not set the strict-transport-security response header.
     """
     render_file_mock = MagicMock()
     monkeypatch.setattr("haproxy.render_file", render_file_mock)
     haproxy_route_relation = build_haproxy_route_relation()
 
     ctx = ops.testing.Context(HAProxyCharm)
-    state = ops.testing.State(relations=[certificates_integration, haproxy_route_relation])
+    state = ops.testing.State(
+        relations=[certificates_integration, haproxy_route_relation],
+    )
+    out = ctx.run(
+        ctx.on.relation_changed(haproxy_route_relation),
+        state,
+    )
+    assert render_file_mock.call_count == 1
+    assert (
+        "http-response set-header Strict-Transport-Security"
+        not in render_file_mock.call_args.args[1]
+    )
+    assert out.unit_status.name == ops.testing.ActiveStatus.name
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_hsts_enabled(monkeypatch: pytest.MonkeyPatch, certificates_integration):
+    """
+    arrange: Prepare a haproxy with haproxy_route and hsts enabled in the config option.
+    act: trigger relation changed.
+    assert: haproxy.conf will set the strict-transport-security response header.
+    """
+    render_file_mock = MagicMock()
+    monkeypatch.setattr("haproxy.render_file", render_file_mock)
+    haproxy_route_relation = build_haproxy_route_relation()
+
+    ctx = ops.testing.Context(HAProxyCharm)
+    state = ops.testing.State(
+        relations=[certificates_integration, haproxy_route_relation],
+        config={"enable-hsts": True},
+    )
     out = ctx.run(
         ctx.on.relation_changed(haproxy_route_relation),
         state,
@@ -37,7 +67,7 @@ def test_hsts_enabled(monkeypatch: pytest.MonkeyPatch, certificates_integration)
     render_file_mock.assert_any_call(
         pathlib.Path("/etc/haproxy/haproxy.cfg"),
         RegexMatcher(
-            'http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;" if { ssl_fc } \n'
+            'http-response set-header Strict-Transport-Security "max-age=2592000;" if { ssl_fc } \n'
         ),
         ANY,
     )
@@ -47,7 +77,7 @@ def test_hsts_enabled(monkeypatch: pytest.MonkeyPatch, certificates_integration)
 @pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
 def test_hsts_disabled_allow_http(monkeypatch: pytest.MonkeyPatch, certificates_integration):
     """
-    arrange: Prepare a haproxy with haproxy_route with one allow_http domain.
+    arrange: Prepare a haproxy with haproxy_route with one allow_http domain and hsts enabled.
     act: trigger relation changed.
     assert: haproxy.conf will set the strict-transport-security response header but not for the allow_http domain.
     """
@@ -57,7 +87,10 @@ def test_hsts_disabled_allow_http(monkeypatch: pytest.MonkeyPatch, certificates_
     haproxy_route_relation.remote_app_data["allow_http"] = "true"
 
     ctx = ops.testing.Context(HAProxyCharm)
-    state = ops.testing.State(relations=[certificates_integration, haproxy_route_relation])
+    state = ops.testing.State(
+        relations=[certificates_integration, haproxy_route_relation],
+        config={"enable-hsts": True},
+    )
     out = ctx.run(
         ctx.on.relation_changed(haproxy_route_relation),
         state,
@@ -67,7 +100,7 @@ def test_hsts_disabled_allow_http(monkeypatch: pytest.MonkeyPatch, certificates_
         pathlib.Path("/etc/haproxy/haproxy.cfg"),
         RegexMatcher(
             re.escape(
-                'http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;" if { ssl_fc }  !{ req.hdr(Host) -m str haproxy.internal }\n'
+                'http-response set-header Strict-Transport-Security "max-age=2592000;" if { ssl_fc }  !{ req.hdr(Host) -m str haproxy.internal }\n'
             )
         ),
         ANY,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Add a configuration option, "enable-hsts" that will enable the Strict-Transport-Security response header for haproxy route for all domains that do not have the allow_http (so they can only be accessed through https).

The Strict-Transport-Security header value is hardcoded to "max-age=2592000" (1 month).

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
