### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -10,9 +10,27 @@ jobs:
   publish-to-edge:
     strategy:
       matrix:
-        working-directory: ['./haproxy-operator', './haproxy-spoe-auth-operator', './haproxy-ddos-protection-configurator']
+        configuration:
+          [
+            {
+              working-directory: "./haproxy-operator",
+              channel: "2.8/edge",
+              tag-prefix: "haproxy",
+            },
+            {
+              working-directory: "./haproxy-spoe-auth-operator",
+              channel: "latest/edge",
+              tag-prefix: "haproxy-spoe-auth",
+            },
+            {
+              working-directory: "./haproxy-ddos-protection-configurator",
+              channel: "latest/edge",
+              tag-prefix: "haproxy-ddos-protection-configurator",
+            },
+          ]
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
     with:
-      channel: 2.8/edge
-      working-directory: ${{ matrix.working-directory }}
+      channel: ${{ matrix.configuration.channel }}
+      working-directory: ${{ matrix.configuration.working-directory }}
+      tag-prefix: ${{ matrix.configuration.tag-prefix }}


### PR DESCRIPTION
Add mapping of configuration values for each  job ( haproxy needs to be on 2.8/edge for example while the other charms is at latest/edge, tag-prefix is also different )

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
