### PR TITLE
chore(docs): Update artifact and Jinja templates

### DIFF
--- a/docs/release-notes/template/_change-artifact-template.yaml
+++ b/docs/release-notes/template/_change-artifact-template.yaml
@@ -1,15 +1,17 @@
-# --- Release notes change artifact ----
+# Version of the artifact schema
+version_schema: 2
 
-schema_version: 1
+# The key holding the change(s)
 changes:
-  - title: ""
-    author: ""
-    type: ""
-    description: ""
-    urls: 
-      pr: ""
-      related_doc: ""
-      related_issue: ""
-    visibility: public
-    highlight: false
+- title: # Use past tense; keep it concise and specific
+  author: # GitHub profile (no emails, no @)
+  type: # options: major, minor, bugfix, breaking, deprecated
+  description: # Use past tense; describe how the change will affect users
+  urls:
+    pr: 
+      - "" # provide one or more links to relevant PRs
+    related_doc: # only applicable if there are documentation changes
+    related_issue: # only applicable if there's a corresponding GitHub issue
+  visibility: # options: public, internal, hidden
+  highlight: # should this change be highlighted in the introduction?
 

--- a/docs/release-notes/template/_release-artifact-template.yaml
+++ b/docs/release-notes/template/_release-artifact-template.yaml
@@ -1,5 +1,10 @@
 # --- Information about release ----
 
+version_schema: 2
+
+# name of workload and version in the release
+workload_with_version:
+
 # list of change artifacts included in the release
 included_changes:
 
@@ -9,9 +14,4 @@ earliest_revision:
 # latest revision included in the release
 latest_revision:
 
-# earliest date included in the release
-earliest_date:
-
-# latest date included in the release 
-latest_date:
 

--- a/docs/release-notes/template/release-template.md.j2
+++ b/docs/release-notes/template/release-template.md.j2
@@ -3,12 +3,12 @@
 # {{ charm_name }} release notes – {{ release_condition }}
 
 These release notes cover new features and changes in {{ charm_name }} for revisions
-{{ earliest_revision }}-{{ latest_revision }} between the dates of {{ earliest_date }} and {{ latest_date }}.
+{{ earliest_revision }}-{{ latest_revision }}.
 
 Main features:
 
 {% for feat in changes -%}
-{%- if feat.highlight == true and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) and (feat.type == "major" or feat.type == "minor") -%}
+{%- if feat.highlight == true and is_visible(feat.visibility, show_internal) and (feat.type in ["major", "minor"]) -%}
 * {{ feat.title }}.
 {% endif -%}
 {% endfor %}
@@ -16,31 +16,33 @@ Main features:
 Main breaking changes:
 
 {% for feat in changes -%}
-{%- if feat.highlight == true and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) and (feat.type == "breaking") -%}
+{%- if feat.highlight == true and is_visible(feat.visibility, show_internal) and (feat.type == "breaking") -%}
 * {{ feat.title }}.
 {% endif -%}
 {% endfor %}
 
 Main bug fixes:
 {% for feat in changes -%}
-{%- if feat.highlight == true and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) and feat.type == "bugfix" -%}
+{%- if feat.highlight == true and is_visible(feat.visibility, show_internal) and feat.type == "bugfix" -%}
 * {{ feat.title }}.
 {% endif -%}
 {% endfor %}
 
-See our [Release policy and schedule](docs/release-notes/landing-page.md).
+See our {ref}`Release policy and schedule <release_notes_index>`.
 
 ## Requirements and compatibility
 
 <!--
 Specify the workload version; link to the workload's release notes if available.
+
 Add information about the requirements for this charm in the table
 below, for instance, a minimum Juju version. 
+
 If the user will need any specific upgrade instructions for this
 release, include those instructions here.
 -->
 
-The charm operates <workload name with version>.
+The charm operates {{ workload_with_version }}.
 
 The table below shows the required or supported versions of the software necessary to operate the charm.
 
@@ -52,18 +54,94 @@ The table below shows the required or supported versions of the software necessa
 | Ubuntu                  | XXXX             |
 | XXXX                    | XXXX             |
 
-## Updates
+{% set ns = namespace(break=False) %}
+{% for feat in changes -%}
+{% if not ns.break -%}
+{%- if feat.type == "breaking" and is_visible(feat.visibility, show_internal) -%}
+## Breaking changes
 
-The following major and minor features were added in this release.
+The following backwards-incompatible changes are included in this release.
+{% set ns.break = True %}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
 
-{% for feat in changes %}
-{%- if (feat.type == "major" or feat.type == "minor") and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
+{% for feat in changes -%}
+{%- if feat.type == "breaking" and is_visible(feat.visibility, show_internal) and feat.visibility != "internal" -%}
 ### {{ feat.title }}
 {{ feat.description }}
 <Add more context and information about the entry>
 
 Relevant links:
+{% if feat.urls.pr is string %}
 * [PR]({{ feat.urls.pr }})
+{% else %}
+{% for pr_url in feat.urls.pr %}
+* [PR]({{ pr_url }})
+{% endfor %}
+{% endif %}
+{% if feat.urls.related_doc is not none -%}
+* [Related documentation]({{ feat.urls.related_doc }})
+{% endif -%}
+{% if feat.urls.related_issue is not none -%}
+* [Related issue]({{ feat.urls.related_issue }})
+{% endif -%}
+
+{% endif -%}
+{% endfor %}
+
+{% set ns = namespace(has_internal=False) %}
+{% for feat in changes -%}
+{% if not ns.has_internal -%}
+{%- if feat.type == "breaking" and is_visible(feat.visibility, show_internal) and feat.visibility == "internal" -%}
+### Internal breaking changes
+{% set ns.has_internal = True %}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
+
+{% for feat in changes -%}
+{%- if feat.type == "breaking" and is_visible(feat.visibility, show_internal) and feat.visibility == "internal" -%}
+#### {{ feat.title }}
+{{ feat.description }}
+<Add more context and information about the entry>
+
+Relevant links:
+{% if feat.urls.pr is string %}
+* [PR]({{ feat.urls.pr }})
+{% else %}
+{% for pr_url in feat.urls.pr %}
+* [PR]({{ pr_url }})
+{% endfor %}
+{% endif %}
+{% if feat.urls.related_doc is not none -%}
+* [Related documentation]({{ feat.urls.related_doc }})
+{% endif -%}
+{% if feat.urls.related_issue is not none -%}
+* [Related issue]({{ feat.urls.related_issue }})
+{% endif -%}
+
+{% endif -%}
+{% endfor %}
+
+## Updates
+
+The following major and minor features were added in this release.
+
+{% for feat in changes %}
+{%- if (feat.type in ["major", "minor"]) and is_visible(feat.visibility, show_internal) and feat.visibility != "internal" -%}
+### {{ feat.title }}
+{{ feat.description }}
+<Add more context and information about the entry>
+
+Relevant links:
+{% if feat.urls.pr is string %}
+* [PR]({{ feat.urls.pr }})
+{% else %}
+{% for pr_url in feat.urls.pr %}
+* [PR]({{ pr_url }})
+{% endfor %}
+{% endif %}
 {% if feat.urls.related_doc is not none -%}
 * [Related documentation]({{ feat.urls.related_doc }})
 {% endif -%}
@@ -74,32 +152,36 @@ Relevant links:
 {% endif -%}
 {% endfor %}
 
-{% set break = False %}
+{% set ns = namespace(has_internal=False) %}
 {% for feat in changes -%}
-{% if not break -%}
-{%- if feat.type == "breaking" and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
-## Breaking changes
-
-The following backwards-incompatible changes are included in this release.
-{% set break = True %}
+{% if not ns.has_internal -%}
+{%- if (feat.type in ["major", "minor"]) and is_visible(feat.visibility, show_internal) and feat.visibility == "internal" -%}
+### Internal updates
+{% set ns.has_internal = True %}
 {% endif -%}
 {% endif -%}
 {% endfor -%}
 
-{% for feat in changes -%}
-{%- if feat.type == "breaking" and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
-### {{ feat.title }}
+{% for feat in changes %}
+{%- if (feat.type in ["major", "minor"]) and is_visible(feat.visibility, show_internal) and feat.visibility == "internal" -%}
+#### {{ feat.title }}
 {{ feat.description }}
 <Add more context and information about the entry>
 
 Relevant links:
+{% if feat.urls.pr is string %}
 * [PR]({{ feat.urls.pr }})
+{% else %}
+{% for pr_url in feat.urls.pr %}
+* [PR]({{ pr_url }})
+{% endfor %}
+{% endif %}
 {% if feat.urls.related_doc is not none -%}
 * [Related documentation]({{ feat.urls.related_doc }})
 {% endif -%}
 {% if feat.urls.related_issue is not none -%}
 * [Related issue]({{ feat.urls.related_issue }})
-{% endif -%}
+{% endif %}
 
 {% endif -%}
 {% endfor %}
@@ -107,31 +189,37 @@ Relevant links:
 ## Bug fixes
 
 {% for feat in changes -%}
-{%- if feat.type == "bugfix" and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
+{%- if feat.type == "bugfix" and is_visible(feat.visibility, show_internal) -%}
 * {{ feat.title }} ([PR]({{ feat.urls.pr }})).
 {% endif -%}
 {% endfor %}
 
-{% set break = False %}
+{% set ns = namespace(break=False) %}
 {% for feat in changes -%}
-{% if not break -%}
-{%- if feat.type == "deprecated" and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
+{% if not ns.break -%}
+{%- if feat.type == "deprecated" and is_visible(feat.visibility, show_internal) -%}
 ## Deprecated
 
 The following features have been deprecated.
-{% set break = True %}
+{% set ns.break = True %}
 {% endif -%}
 {% endif -%}
 {% endfor -%}
 
 {% for feat in changes -%}
-{%- if feat.type == "deprecated" and (feat.visibility == "public" or (feat.visibility == "internal" and show_internal == true) ) -%}
+{%- if feat.type == "deprecated" and is_visible(feat.visibility, show_internal) -%}
 ### {{ feat.title }}
 {{ feat.description }}
 <Add more context and information about the entry>
 
 Relevant links:
+{% if feat.urls.pr is string %}
 * [PR]({{ feat.urls.pr }})
+{% else %}
+{% for pr_url in feat.urls.pr %}
+* [PR]({{ pr_url }})
+{% endfor %}
+{% endif %}
 {% if feat.urls.related_doc is not none -%}
 * [Related documentation]({{ feat.urls.related_doc }})
 {% endif -%}


### PR DESCRIPTION
Applicable spec: ISD263

### Overview

Update artifact and Jinja templates based on updates in ISD263.

### Rationale

* Update logic in the Jinja template to separate internal updates from non-internal updates.
* Update the `urls.PR` key in the change artifacts to take in an array of URLs, and update the logic in the Jinja template to account for this possibility. 
* Update the Jinja template to move the “Breaking changes” section earlier in the release notes.
* Update the release artifact schema to include `workload_with_version`, and incorporate logic into the Jinja template to render this in the output. Also remove the keys `earliest_date` and `latest_date`. Add a `version_schema` key to the release artifact to account for the changes.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [N/A] The documentation for charmhub is updated
- [N/A] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [N/A] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
