### PR TITLE
fix: parameterized app name in product tf module

### DIFF
--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -31,12 +31,12 @@ module "haproxy" {
 }
 
 resource "juju_application" "grafana_agent" {
-  name       = "grafana-agent"
+  name       = var.grafana_agent.app_name
   model_uuid = var.model_uuid
   units      = 1
 
   charm {
-    name     = var.grafana_agent.app_name
+    name     = "grafana-agent"
     revision = var.grafana_agent.revision
     channel  = var.grafana_agent.channel
     base     = var.haproxy.base


### PR DESCRIPTION
Applicable spec: NA

### Overview

the parameterized name was used in the charm block, which determines the charm to install. It should instead be used for the 'name' config parameter, see [docs](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application#name-1)

### Rationale

Previous change breaks the module if anything other than "grafana-agent" is used for the grafana agent app name.

### Juju Events Changes

NA

### Module Changes

NA

### Library Changes

NA

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
