### PR TITLE
bump haproxy-route-tcp libpatch

### DIFF
--- a/haproxy-operator/lib/charms/haproxy/v0/haproxy_route_tcp.py
+++ b/haproxy-operator/lib/charms/haproxy/v0/haproxy_route_tcp.py
@@ -174,7 +174,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
An amendment to PR #287 that updates haproxy-route-tcp lib and did not increment libpatch  

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)


<!-- Explanation for any unchecked items above -->
