### PR TITLE
Add app_anme and missing requires to Terraform product

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@ Each revision is versioned by the date of the revision.
 
 ## 2025-12-19
 
+- Added `app_name` and missing endpoint outputs to the Terraform product.
+
+## 2025-12-19
+
 - Added support for custom gRPC frontend port using the `external_grpc_port` attribute.
 
 ## 2025-12-18

--- a/terraform/charm/outputs.tf
+++ b/terraform/charm/outputs.tf
@@ -15,7 +15,8 @@ output "provides" {
 
 output "requires" {
   value = {
-    certificates = "certificates"
-    reverseproxy = "reverseproxy"
+    certificates     = "certificates"
+    receive_ca_certs = "receive-ca-certs"
+    reverseproxy     = "reverseproxy"
   }
 }

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -8,7 +8,7 @@ output "grafana_agent" {
 
 output "haproxy_app_name" {
   description = "Name of the deployed haproxy application."
-  value       = haproxy.haproxy.app_name
+  value       = module.haproxy.app_name
 }
 
 output "provides" {

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -6,6 +6,11 @@ output "grafana_agent" {
   value       = juju_application.grafana_agent.name
 }
 
+output "haproxy_app_name" {
+  description = "Name of the deployed haproxy application."
+  value       = haproxy.haproxy.app_name
+}
+
 output "provides" {
   value = {
     ingress          = "ingress"
@@ -18,6 +23,7 @@ output "requires" {
   value = {
     reverseproxy                = "reverseproxy"
     certificates                = "certificates"
+    receive_ca_certs            = "receive-ca-certs"
     metrics_endpoint            = "metrics-endpoint"
     send_remote_write           = "send-remote-write"
     grafana_dashboards_consumer = "grafana-dashboards-consumer"


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [ ] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
