### PR TITLE
Allow hostname to have a port component

### DIFF
--- a/docs/release-notes/artifacts/pr0317.yaml
+++ b/docs/release-notes/artifacts/pr0317.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+title: Allow hostname matching with port in Host header
+author: tphan025
+type: minor
+description: >
+  Updated HAProxy ACL configuration to handle Host headers that include port numbers.
+  Changed from `req.hdr(Host) -m str` to `req.hdr(host),field(1,:) -i` to extract only
+  the hostname portion before the colon, allowing requests with ports (e.g., example.com:8080)
+  to match hostname ACLs correctly. This also makes hostname matching case-insensitive.
+urls:
+  - https://github.com/canonical/haproxy-operator/pull/317
+visibility: public
+highlight: false

--- a/haproxy-operator/src/state/haproxy_route.py
+++ b/haproxy-operator/src/state/haproxy_route.py
@@ -401,7 +401,7 @@ class HaproxyRouteRequirersInformation:
         allow_http_acls: list[str] = []
         for backend in self.backends:
             if backend.application_data.allow_http:
-                acl = f"{{ req.hdr(Host) -m str {' '.join(backend.hostname_acls)} }}"
+                acl = f"{{ req.hdr(host),field(1,:) -i {' '.join(backend.hostname_acls)} }}"
                 if backend.path_acl_required:
                     acl += f" {{ path_beg -i {' '.join(backend.application_data.paths)} }}"
                 if backend.deny_path_acl_required:

--- a/haproxy-operator/templates/haproxy_route.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route.cfg.j2
@@ -16,7 +16,7 @@ frontend haproxy
 {{ ddos_protection_rules() }}
 
 {% for spoe_auth_info in spoe_auth_info_list  %}
-    acl oidc_host_{{ spoe_auth_info.id }} req.hdr(Host) -m str {{ spoe_auth_info.hostname }}
+    acl oidc_host_{{ spoe_auth_info.id }} req.hdr(host),field(1,:) -i {{ spoe_auth_info.hostname }}
     acl oidc_callback_path_{{ spoe_auth_info.id }} path_beg -i {{ spoe_auth_info.oidc_callback_path }}
     use_backend spoe_oidc_callback_{{ spoe_auth_info.id }} if oidc_host_{{ spoe_auth_info.id }} oidc_callback_path_{{ spoe_auth_info.id }}
 
@@ -31,7 +31,7 @@ frontend haproxy
 {% if backend.path_acl_required %}
     acl acl_path_{{ backend.backend_name }} path_beg -i {% for path in backend.application_data.paths %}{{ path }} {% endfor +%}
 {% endif %}
-    acl acl_host_{{ backend.backend_name }} req.hdr(Host) -m str {% for hostname in backend.hostname_acls%}{{hostname}} {% endfor +%}
+    acl acl_host_{{ backend.backend_name }} req.hdr(host),field(1,:) -i {% for hostname in backend.hostname_acls%}{{hostname}} {% endfor +%}
 {% if backend.deny_path_acl_required %}
     acl acl_deny_path_{{ backend.backend_name }} path_beg -i {% for path in backend.application_data.deny_paths %}{{ path }} {% endfor +%}
 {% endif %}

--- a/haproxy-operator/templates/haproxy_route_grpc.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_grpc.cfg.j2
@@ -2,7 +2,7 @@
 frontend {{ backend.backend_name }}
     mode http
     bind [::]:{{ backend.application_data.external_grpc_port }} v4v6 ssl crt /var/lib/haproxy/certs alpn h2
-    acl acl_host_{{ backend.backend_name }} req.hdr(Host) -m str {% for hostname in backend.hostname_acls %}{{hostname}} {% endfor +%}
+    acl acl_host_{{ backend.backend_name }} req.hdr(host),field(1,:) -i {% for hostname in backend.hostname_acls %}{{hostname}} {% endfor +%}
     {% if backend.path_acl_required %}
     acl acl_path_{{ backend.backend_name }} path_beg -i {% for path in backend.application_data.paths %}{{ path }} {% endfor +%}
     {% endif %}

--- a/haproxy-operator/tests/unit/test_haproxy_route_lib.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_lib.py
@@ -121,7 +121,7 @@ def test_haproxy_route_requirer_information(
         ca_certs_configured=False,
     )
     assert haproxy_route_information.acls_for_allow_http == [
-        "{ req.hdr(Host) -m str example.com } { path_beg -i /path } !{ path_beg -i /private }"
+        "{ req.hdr(host),field(1,:) -i example.com } { path_beg -i /path } !{ path_beg -i /private }"
     ]
 
 

--- a/haproxy-operator/tests/unit/test_hsts.py
+++ b/haproxy-operator/tests/unit/test_hsts.py
@@ -100,7 +100,7 @@ def test_hsts_disabled_allow_http(monkeypatch: pytest.MonkeyPatch, certificates_
         pathlib.Path("/etc/haproxy/haproxy.cfg"),
         RegexMatcher(
             re.escape(
-                'http-response set-header Strict-Transport-Security "max-age=2592000" if { ssl_fc }  !{ req.hdr(Host) -m str haproxy.internal }\n'
+                'http-response set-header Strict-Transport-Security "max-age=2592000" if { ssl_fc }  !{ req.hdr(host),field(1,:) -i haproxy.internal }\n'
             )
         ),
         ANY,


### PR DESCRIPTION
fixes #288 

Update hostname ACL to `req.hdr(host),field(1,:)`, effectively allowing hostname to have a port component. Both of the following curl commands should work under this condition:

```
curl -H "Host: hostname:443" <ip>
curl -H "Host: hostname <ip>
```

also add -i for case insensitivity

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
