### PR TITLE
Update HAProxy config to track connections per minute instead of rate limit

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-01-09
+
+- Updated HAProxy config to track connections per minute instead of rate limit.
+
 ## 2025-12-17
 
 - Added the DDoS defaults in the HAProxy config files and a config option to disable the defaults.

--- a/docs/release-notes/artifacts/pr0319.yaml
+++ b/docs/release-notes/artifacts/pr0319.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-title: Update HAProxy config to track connections per minute instead of rate limit
+title: Updated HAProxy config to track connections per minute instead of rate limit
 author: swetha1654
 type: minor
 description: >

--- a/docs/release-notes/artifacts/pr0319.yaml
+++ b/docs/release-notes/artifacts/pr0319.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+title: Update HAProxy config to track connections per minute instead of rate limit
+author: swetha1654
+type: minor
+description: >
+  Currently the haproxy-route library exposes the `rate_limit_connections_per_minute` attribute,
+  however the underlying HAProxy configuration tracks request rate limiting using the 
+  `http_req_rate` parameter. This update modifies the HAProxy configuration to use
+  `conn_rate` instead.
+urls:
+  - https://github.com/canonical/haproxy-operator/pull/319
+visibility: public
+highlight: false

--- a/haproxy-operator/templates/haproxy_route.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route.cfg.j2
@@ -75,8 +75,9 @@ backend {{ backend.backend_name }}
     http-check send hdr Host {{ backend.hostname_acls[0] }}
 {% if backend.application_data.rate_limit %}
     http-request track-sc0 src table  haproxy_peers/{{ backend.backend_name }}_rate_limit
-    http-request {{ backend.application_data.rate_limit.policy.value }} if { sc_http_req_rate(0,haproxy_peers/{{ backend.backend_name }}_rate_limit) gt {{ backend.application_data.rate_limit.connections_per_minute }} }
+    http-request {{ backend.application_data.rate_limit.policy.value }} if { sc_conn_rate(0,haproxy_peers/{{ backend.backend_name }}_rate_limit) gt {{ backend.application_data.rate_limit.connections_per_minute }} }
 {% endif %}
+
 {% if backend.application_data.bandwidth_limit.download %}
 
     filter bwlim-out download default-limit {{ backend.application_data.bandwidth_limit.download }} default-period 1s


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Currently the `haproxy-route` library exposes the `rate_limit_connections_per_minute` attribute, however the underlying HAProxy configuration tracks request rate limiting using the `http_req_rate` parameter. This update modifies the HAProxy configuration to use `conn_rate` instead.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
