### PR TITLE
Update log-format. Add grafana panels for ddos.

### DIFF
--- a/docs/release-notes/artifacts/pr0321.yaml
+++ b/docs/release-notes/artifacts/pr0321.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+title: Update log-format and add new panels to the grafana dashboard to analise ddos attacks.
+author: javierdelapuente
+type: minor
+description: >
+  Run `systemd-tmpfiles --create` when installing haproxy to fix /var/log permissions.
+  Update the log-format to "ip=%ci method=%HM path=%HP status=%ST bytes=%B".
+  Add new grafana panels with:
+  1. Top 10 client IPs with maximum requests over the last 5 minutes.
+  2. Top 10 client IPs with maximum bytes in their requests over the last 5 minutes.
+  3. Top 10 URLs queried over the last 5 minutes.
+urls:
+  - https://github.com/canonical/haproxy-operator/pull/321
+visibility: public
+highlight: false

--- a/docs/release-notes/artifacts/pr0321.yaml
+++ b/docs/release-notes/artifacts/pr0321.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-title: Add new panels to the grafana dashboard to analyse ddos attacks.
+title: Added new panels to the grafana dashboard to analyse ddos attacks.
 author: javierdelapuente
 type: minor
 description: >

--- a/docs/release-notes/artifacts/pr0321.yaml
+++ b/docs/release-notes/artifacts/pr0321.yaml
@@ -1,11 +1,11 @@
 schema_version: 1
-title: Added new panels to the grafana dashboard to analyse ddos attacks.
+title: Added new panels to the grafana dashboard to analyse DDoS attacks.
 author: javierdelapuente
 type: minor
 description: >
   Add new grafana panels with:
-  1. Top 10 client IPs with maximum requests over the last 5 minutes.
-  2. Top 10 client IPs with maximum bytes in their requests over the last 5 minutes.
+  1. Top 10 client IPs with more requests over the last 5 minutes.
+  2. Top 10 client IPs with more bytes in their requests over the last 5 minutes.
   3. Top 10 URLs queried over the last 5 minutes.
   Run `systemd-tmpfiles --create` when installing haproxy to fix /var/log permissions.
 urls:

--- a/docs/release-notes/artifacts/pr0321.yaml
+++ b/docs/release-notes/artifacts/pr0321.yaml
@@ -1,14 +1,13 @@
 schema_version: 1
-title: Update log-format and add new panels to the grafana dashboard to analise ddos attacks.
+title: Add new panels to the grafana dashboard to analise ddos attacks.
 author: javierdelapuente
 type: minor
 description: >
-  Run `systemd-tmpfiles --create` when installing haproxy to fix /var/log permissions.
-  Update the log-format to "ip=%ci method=%HM path=%HP status=%ST bytes=%B".
   Add new grafana panels with:
   1. Top 10 client IPs with maximum requests over the last 5 minutes.
   2. Top 10 client IPs with maximum bytes in their requests over the last 5 minutes.
   3. Top 10 URLs queried over the last 5 minutes.
+  Run `systemd-tmpfiles --create` when installing haproxy to fix /var/log permissions.
 urls:
   - https://github.com/canonical/haproxy-operator/pull/321
 visibility: public

--- a/docs/release-notes/artifacts/pr0321.yaml
+++ b/docs/release-notes/artifacts/pr0321.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-title: Add new panels to the grafana dashboard to analise ddos attacks.
+title: Add new panels to the grafana dashboard to analyse ddos attacks.
 author: javierdelapuente
 type: minor
 description: >

--- a/haproxy-operator/src/grafana_dashboards/haproxy.json
+++ b/haproxy-operator/src/grafana_dashboards/haproxy.json
@@ -11679,6 +11679,319 @@
       ],
       "title": "Process Misc",
       "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 223,
+      "panels": [],
+      "title": "Traffic Analysis",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${lokids}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 60
+      },
+      "id": 224,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10,\n  sum by (ip) (\n    rate({filename=\"/var/log/haproxy.log\"} | logfmt | ip != \"\" | __error__=\"\" [5m])\n  )\n)",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 IPs per requests per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${lokids}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 60
+      },
+      "id": 222,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10,\n  sum by (ip) (\n    rate({filename=\"/var/log/haproxy.log\"} | logfmt | unwrap bytes | __error__=\"\" [5m])\n  )\n)",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 IPs per bytes per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${lokids}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{newpath=\"\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 60
+      },
+      "id": 221,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10,\n  sum by (path_extracted) (\n    rate({filename=\"/var/log/haproxy.log\"} | logfmt | ip != \"\" | __error__=\"\" [5m])\n  )\n)",
+          "hide": false,
+          "legendFormat": "path={{path_extracted}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 paths queried per second",
+      "type": "timeseries"
     }
   ],
   "refresh": "1m",

--- a/haproxy-operator/src/grafana_dashboards/haproxy.json
+++ b/haproxy-operator/src/grafana_dashboards/haproxy.json
@@ -11776,7 +11776,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "topk(10,\n  sum by (ip) (\n    rate({filename=\"/var/log/haproxy.log\"} | logfmt | ip != \"\" | __error__=\"\" [5m])\n  )\n)",
+          "expr": "topk(10,sum by(ip)(rate({filename=\"/var/log/haproxy.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | regexp \"haproxy\\\\[\\\\d+\\\\]: (?P<ip>.*):(?P<port>\\\\d+) .* (?P<status_code>\\\\d+) (?P<bytes_sent>\\\\d+) - - .* \\\"(?P<method>\\\\w+) (?P<uri>\\\\S+)\" | ip!=\"\" | __error__=\"\"[5m])))",
           "queryType": "range",
           "refId": "A"
         }
@@ -11867,7 +11867,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "topk(10,\n  sum by (ip) (\n    rate({filename=\"/var/log/haproxy.log\"} | logfmt | unwrap bytes | __error__=\"\" [5m])\n  )\n)",
+          "expr": "topk(10,sum by(ip)(rate({filename=\"/var/log/haproxy.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | regexp \"haproxy\\\\[\\\\d+\\\\]: (?P<ip>.*):(?P<port>\\\\d+) .* (?P<status_code>\\\\d+) (?P<bytes>\\\\d+) - - .* \\\"(?P<method>\\\\w+) (?P<uri>\\\\S+)\" | unwrap bytes | __error__=\"\"[5m])))",
           "queryType": "range",
           "refId": "A"
         }
@@ -11983,9 +11983,9 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "topk(10,\n  sum by (path_extracted) (\n    rate({filename=\"/var/log/haproxy.log\"} | logfmt | ip != \"\" | __error__=\"\" [5m])\n  )\n)",
+          "expr": "topk(10,sum by(uri)(rate({filename=\"/var/log/haproxy.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | regexp \"haproxy\\\\[\\\\d+\\\\]: (?P<ip>.*):(?P<port>\\\\d+) .* (?P<status_code>\\\\d+) (?P<bytes>\\\\d+) - - .* \\\"(?P<method>\\\\w+) (?P<uri>\\\\S+)\" | unwrap bytes | __error__=\"\"[5m])))",
           "hide": false,
-          "legendFormat": "path={{path_extracted}}",
+          "legendFormat": "path={{uri}}",
           "queryType": "range",
           "refId": "A"
         }

--- a/haproxy-operator/templates/haproxy.cfg.j2
+++ b/haproxy-operator/templates/haproxy.cfg.j2
@@ -30,7 +30,7 @@ global
 defaults
     log global
     mode http
-    option httplog
+    log-format "ip=%ci method=%HM path=%HP status=%ST bytes=%B"
     option dontlognull
     retries 3
     timeout queue 20000

--- a/haproxy-operator/templates/haproxy.cfg.j2
+++ b/haproxy-operator/templates/haproxy.cfg.j2
@@ -30,7 +30,7 @@ global
 defaults
     log global
     mode http
-    log-format "ip=%ci method=%HM path=%HP status=%ST bytes=%B"
+    option httplog
     option dontlognull
     retries 3
     timeout queue 20000


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Run `systemd-tmpfiles --create` when installing haproxy. The reason is that the /var/log did not have the correct permissions without booting the machine, and syslog could not write to /var/log/haproxy.log.

<img width="1687" height="852" alt="image" src="https://github.com/user-attachments/assets/9f9e4c1c-e806-44ba-a289-83bceced1b09" />

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
