### PR TITLE
fix: add missing settings from haproxy-route-tcp relation template

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-01-14
+
+- Added missing settings from haproxy-route-tcp relation template.
+
 ## 2026-01-09
 
 - Updated HAProxy config to track connections per minute instead of rate limit.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
-## 2026-01-14
+## 2026-01-15
 
 - Added missing settings from haproxy-route-tcp relation template.
 

--- a/docs/release-notes/artifacts/pr0325.yaml
+++ b/docs/release-notes/artifacts/pr0325.yaml
@@ -1,0 +1,13 @@
+version_schema: 2
+changes:
+  - title: Added missing settings from haproxy-route-tcp relation template
+    author: skatsaounis
+    type: bugfix
+    description: >
+      Added missing settings to the haproxy-route-tcp relation template, including
+      frontend "retries", "option redispatch", and backend "balance", and "hash-type consistent".
+    urls:
+      pr:
+        - https://github.com/canonical/haproxy-operator/pull/325
+    visibility: public
+    highlight: false

--- a/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
@@ -17,6 +17,12 @@ maxconn {{ server.maxconn }}
 frontend {{ endpoint.name }}
     mode tcp
     option tcplog
+{% if endpoint.application_data.retry %}
+    retries {{ endpoint.application_data.retry.count }}
+{% if endpoint.application_data.retry.redispatch %}
+    option redispatch
+{% endif %}
+{% endif %}
     bind [::]:{{ endpoint.application_data.port }} v4v6 {% if endpoint.application_data.tls_terminate %} ssl crt {{ haproxy_crt_dir }} {% endif +%}
 {% if endpoint.application_data.enforce_tls %}
     tcp-request content accept if { req_ssl_hello_type 1 }
@@ -36,6 +42,12 @@ frontend {{ endpoint.name }}
 
 backend {{ endpoint.name }}
     mode tcp
+{% if endpoint.application_data.load_balancing %}
+    balance {{ endpoint.application_data.load_balancing.algorithm }}
+{% if endpoint.application_data.load_balancing.consistent_hashing %}
+    hash-type consistent
+{% endif %}
+{% endif %}
 {% for option in endpoint.tcp_check_options %}
     {{ option }}
 {% endfor %}

--- a/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
@@ -43,7 +43,7 @@ frontend {{ endpoint.name }}
 backend {{ endpoint.name }}
     mode tcp
 {% if endpoint.application_data.load_balancing %}
-    balance {{ endpoint.application_data.load_balancing.algorithm }}
+    balance {{ endpoint.application_data.load_balancing.algorithm.value }}
 {% if endpoint.application_data.load_balancing.consistent_hashing %}
     hash-type consistent
 {% endif %}

--- a/haproxy-operator/tests/integration/conftest.py
+++ b/haproxy-operator/tests/integration/conftest.py
@@ -307,7 +307,7 @@ def any_charm_haproxy_route_requirer_fixture(
     )
 
 
-@pytest.fixture(scope="function", name="any_charm_haproxy_route_tcp_requirer_base")
+@pytest.fixture(scope="module", name="any_charm_haproxy_route_tcp_requirer_base")
 @pytestconfig_arg_no_deploy(application=ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION)
 def any_charm_haproxy_route_tcp_requirer_base_fixture(
     _pytestconfig: pytest.Config, juju: jubilant.Juju
@@ -315,11 +315,6 @@ def any_charm_haproxy_route_tcp_requirer_base_fixture(
     """Deploy any-charm and configure it to serve as a requirer for the haproxy-route
     integration.
     """
-    if ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION in juju.status().apps:
-        logger.warning(
-            "Using existing application: %s", ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION
-        )
-        return ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION
     juju.deploy(
         "any-charm",
         app=ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION,

--- a/haproxy-operator/tests/integration/conftest.py
+++ b/haproxy-operator/tests/integration/conftest.py
@@ -307,9 +307,9 @@ def any_charm_haproxy_route_requirer_fixture(
     )
 
 
-@pytest.fixture(scope="function", name="any_charm_haproxy_route_tcp_requirer")
+@pytest.fixture(scope="function", name="any_charm_haproxy_route_tcp_requirer_base")
 @pytestconfig_arg_no_deploy(application=ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION)
-def any_charm_haproxy_route_tcp_requirer_fixture(
+def any_charm_haproxy_route_tcp_requirer_base_fixture(
     _pytestconfig: pytest.Config, juju: jubilant.Juju
 ):
     """Deploy any-charm and configure it to serve as a requirer for the haproxy-route
@@ -340,3 +340,32 @@ def any_charm_haproxy_route_tcp_requirer_fixture(
         timeout=JUJU_WAIT_TIMEOUT,
     )
     return ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION
+
+
+@pytest.fixture(name="any_charm_haproxy_route_tcp_requirer")
+def any_charm_haproxy_route_tcp_requirer_fixture(
+    any_charm_haproxy_route_tcp_requirer_base: str,
+    juju: jubilant.Juju,
+):
+    """Provide haproxy route tcp requirer and clean up test-specific relations after each test.
+
+    This function-scoped fixture wraps the module-scoped any_charm_haproxy_route_tcp_requirer_base
+    and ensures that relations created during tests are removed, while preserving the
+    base application for reuse across tests.
+    """
+    yield any_charm_haproxy_route_tcp_requirer_base
+
+    # Remove all relations except peer relations
+    app_name = any_charm_haproxy_route_tcp_requirer_base
+    if app_name not in juju.status().apps:
+        return
+
+    for endpoint, app_status_relation in juju.status().apps[app_name].relations.items():
+        for relation in app_status_relation:
+            if relation.related_app == app_name:
+                continue
+            juju.remove_relation(f"{app_name}:{endpoint}", relation.related_app)
+
+    juju.wait(
+        lambda status: (jubilant.all_agents_idle(status)),
+    )

--- a/haproxy-operator/tests/integration/conftest.py
+++ b/haproxy-operator/tests/integration/conftest.py
@@ -307,17 +307,22 @@ def any_charm_haproxy_route_requirer_fixture(
     )
 
 
-@pytest.fixture(scope="function", name="any_charm_haproxy_route_tcp_requirer_base")
+@pytest.fixture(scope="function", name="any_charm_haproxy_route_tcp_requirer")
 @pytestconfig_arg_no_deploy(application=ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION)
-def any_charm_haproxy_route_tcp_requirer_base_fixture(
-    _pytestconfig: pytest.Config, juju: jubilant.Juju
+def any_charm_haproxy_route_tcp_requirer_fixture(
+    request: pytest.FixtureRequest, _pytestconfig: pytest.Config, juju: jubilant.Juju
 ):
     """Deploy any-charm and configure it to serve as a requirer for the haproxy-route
     integration.
+
+    This fixture accepts a parameter (suffix) to create unique application names for each test.
     """
+    suffix = getattr(request, "param", "basic")
+    app_name = f"{ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION}-{suffix}"
+
     juju.deploy(
         "any-charm",
-        app=ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION,
+        app=app_name,
         channel="beta",
         config={
             "src-overwrite": json.dumps(
@@ -334,38 +339,8 @@ def any_charm_haproxy_route_tcp_requirer_base_fixture(
         },
     )
     juju.wait(
-        lambda status: (
-            jubilant.all_active(status, ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION)
-        ),
+        lambda status: jubilant.all_active(status, app_name),
         timeout=JUJU_WAIT_TIMEOUT,
     )
-    return ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION
 
-
-@pytest.fixture(name="any_charm_haproxy_route_tcp_requirer")
-def any_charm_haproxy_route_tcp_requirer_fixture(
-    any_charm_haproxy_route_tcp_requirer_base: str,
-    juju: jubilant.Juju,
-):
-    """Provide haproxy route tcp requirer and clean up test-specific relations after each test.
-
-    This function-scoped fixture wraps the module-scoped any_charm_haproxy_route_tcp_requirer_base
-    and ensures that relations created during tests are removed, while preserving the
-    base application for reuse across tests.
-    """
-    yield any_charm_haproxy_route_tcp_requirer_base
-
-    # Remove all relations except peer relations
-    app_name = any_charm_haproxy_route_tcp_requirer_base
-    if app_name not in juju.status().apps:
-        return
-
-    for endpoint, app_status_relation in juju.status().apps[app_name].relations.items():
-        for relation in app_status_relation:
-            if relation.related_app == app_name:
-                continue
-            juju.remove_relation(f"{app_name}:{endpoint}", relation.related_app)
-
-    juju.wait(
-        lambda status: (jubilant.all_agents_idle(status)),
-    )
+    return app_name

--- a/haproxy-operator/tests/integration/haproxy_route_tcp_requirer.py
+++ b/haproxy-operator/tests/integration/haproxy_route_tcp_requirer.py
@@ -106,12 +106,8 @@ class AnyCharm(AnyCharmBase):
             check_fall=3,
             check_send="ping\r\n",
             check_expect="pong",
-            load_balancing={
-                "algorithm": "source",
-                "consistent_hashing": True
-            },
-            retry={
-                "count": 3,
-                "redispatch": True
-            }
+            load_balancing_algorithm="source",
+            load_balancing_consistent_hashing=True,
+            retry_count=3,
+            retry_redispatch=True,
         )

--- a/haproxy-operator/tests/integration/haproxy_route_tcp_requirer.py
+++ b/haproxy-operator/tests/integration/haproxy_route_tcp_requirer.py
@@ -93,3 +93,25 @@ class AnyCharm(AnyCharmBase):
             check_send="ping\r\n",
             check_expect="pong",
         )
+
+    def update_relation_with_sticky_sessions(self):
+        """Update haproxy-route-tcp relation data with sticky sessions"""
+        self._haproxy_route_tcp.provide_haproxy_route_tcp_requirements(
+            port=4444,
+            backend_port=4000,
+            sni=CNAME,
+            check_type=TCPHealthCheckType.GENERIC,
+            check_interval=60,
+            check_rise=3,
+            check_fall=3,
+            check_send="ping\r\n",
+            check_expect="pong",
+            load_balancing={
+                "algorithm": "source",
+                "consistent_hashing": True
+            },
+            retry={
+                "count": 3,
+                "redispatch": True
+            }
+        )

--- a/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
+++ b/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
@@ -83,7 +83,6 @@ def test_haproxy_route_tcp_with_sticky_sessions(
         for entry in [
             "retries 3",
             "option redispatch",
-            "option http-server-close",
             "balance source",
             "hash-type consistent",
         ]

--- a/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
+++ b/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
@@ -13,7 +13,7 @@ from .helper import get_unit_ip_address
 
 
 @pytest.mark.abort_on_fail
-async def test_haproxy_route_tcp(
+def test_haproxy_route_tcp(
     configured_application_with_tls: str,
     any_charm_haproxy_route_tcp_requirer: str,
     juju: jubilant.Juju,
@@ -51,7 +51,7 @@ async def test_haproxy_route_tcp(
 
 
 @pytest.mark.abort_on_fail
-async def test_haproxy_route_tcp_with_sticky_sessions(
+def test_haproxy_route_tcp_with_sticky_sessions(
     configured_application_with_tls: str,
     any_charm_haproxy_route_tcp_requirer: str,
     juju: jubilant.Juju,

--- a/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
+++ b/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
@@ -51,11 +51,6 @@ def test_haproxy_route_tcp(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.parametrize(
-    "any_charm_haproxy_route_tcp_requirer",
-    ["sticky-sessions"],
-    indirect=True,
-)
 def test_haproxy_route_tcp_with_sticky_sessions(
     configured_application_with_tls: str,
     any_charm_haproxy_route_tcp_requirer: str,

--- a/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
+++ b/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
@@ -51,6 +51,11 @@ def test_haproxy_route_tcp(
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.parametrize(
+    "any_charm_haproxy_route_tcp_requirer",
+    ["sticky-sessions"],
+    indirect=True,
+)
 def test_haproxy_route_tcp_with_sticky_sessions(
     configured_application_with_tls: str,
     any_charm_haproxy_route_tcp_requirer: str,
@@ -64,8 +69,6 @@ def test_haproxy_route_tcp_with_sticky_sessions(
         f"{configured_application_with_tls}:haproxy-route-tcp",
         any_charm_haproxy_route_tcp_requirer,
     )
-    # We set the removed retry-interval config option here as
-    # ingress-configurator is not yet synced with the updated lib. This will be removed.
     juju.run(
         f"{any_charm_haproxy_route_tcp_requirer}/0",
         "rpc",


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The haproxy-route-tcp relation supports setting `retry_count`, `retry_redispatch`, `load_balancing_algorithm`, `load_balancing_consistent_hashing` in the `HaproxyRouteTcpRequirer` and is adding them to the relation databag with `_generate_application_data`. This PR is extending the `haproxy_route_tcp.cfg.j2` Jinja template to use them.

### Rationale

The current template is not respecting the values set to the application databag.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
