### PR TITLE
Pin all docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ myst-parser==4.0.1
 sphinx-autobuild==2024.10.3
 sphinx-design==0.6.1
 sphinx-notfound-page==1.1.0
-sphinx-reredirects==1.1.0
+sphinx-reredirects==0.1.6
 sphinx-tabs==3.4.7
 sphinxcontrib-jquery==4.1
 sphinxext-opengraph==0.13.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ canonical-sphinx==0.5.2
 
 # Extensions previously auto-loaded by canonical-sphinx
 myst-parser==4.0.1
-sphinx-autobuild==2025.8.25
+sphinx-autobuild==2024.10.3
 sphinx-design==0.6.1
 sphinx-notfound-page==1.1.0
 sphinx-reredirects==1.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,33 +1,33 @@
 # Canonical theme (still needed for Furo theme and custom templates)
-canonical-sphinx>=0.5.1
+canonical-sphinx==0.5.2
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser
-sphinx-autobuild
-sphinx-design
-sphinx-notfound-page
-sphinx-reredirects
-sphinx-tabs
-sphinxcontrib-jquery
-sphinxext-opengraph
+myst-parser==4.0.1
+sphinx-autobuild==2025.8.25
+sphinx-design==0.6.1
+sphinx-notfound-page==1.1.0
+sphinx-reredirects==1.1.0
+sphinx-tabs==3.4.7
+sphinxcontrib-jquery==4.1
+sphinxext-opengraph==0.13.0
 
 # Extra extensions, previously bundled as canonical-sphinx-extensions
-sphinx-config-options>=0.1.0
-sphinx-contributor-listing>=0.1.0
-sphinx-filtered-toctree>=0.1.0
-sphinx-related-links>=0.1.1
-sphinx-roles>=0.1.0
-sphinx-terminal>=1.0.2
-sphinx-ubuntu-images>=0.1.0
-sphinx-youtube-links>=0.1.0
+sphinx-config-options==0.1.0
+sphinx-contributor-listing==0.1.0
+sphinx-filtered-toctree==0.1.0
+sphinx-related-links==0.1.2
+sphinx-roles==0.1.0
+sphinx-terminal==1.0.3
+sphinx-ubuntu-images==0.1.0
+sphinx-youtube-links==0.1.0
 
 # Other dependencies
-packaging
-sphinxcontrib-svg2pdfconverter[CairoSVG]
-sphinx-last-updated-by-git
-sphinx-sitemap
+packaging==25.0
+sphinxcontrib-svg2pdfconverter[CairoSVG]==2.0.0
+sphinx-last-updated-by-git==0.3.8
+sphinx-sitemap==2.9.0
 
 # Vale dependencies
-rst2html
-vale
-sphinxcontrib-mermaid
+rst2html==2020.7.4
+vale==3.13.0.0
+sphinxcontrib-mermaid==2.0.0


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Pin all docs dependencies. The pipeline is currently broken because of this.

This PR requires a force merge, as the pipeline builds the doc also for the main branch, and that one is currently broken.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is updated
- [ ] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
