### PR TITLE
Fixed issues with the DDoS protection configurator charm found in staging

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-01-19
+
+- Removed "assumes juju >= 3.6" for the HAProxy DDoS protection configurator charm.
+
 ## 2026-01-16
 
 - Added terraform modules for the HAProxy DDoS Protection configurator charm.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-01-19
 
-- Removed "assumes juju >= 3.6" for the HAProxy DDoS protection configurator charm.
+- Fixed issues with the DDoS protection configurator charm found in staging.
 
 ## 2026-01-16
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-01-14
 
-- Added provider support for the `ddos_protection` interface on the HAProxy charm.
+- Added requirer support for the `ddos_protection` interface on the HAProxy charm.
 
 ## 2026-01-09
 

--- a/docs/release-notes/artifacts/pr0323.yaml
+++ b/docs/release-notes/artifacts/pr0323.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
-title: Added provider support for the `ddos_protection` interface on the HAProxy charm.
+title: Added requirer support for the `ddos_protection` interface on the HAProxy charm.
 author: swetha1654
 type: major
 description: >
-  Implemented the provider side of the `ddos_protection` interface in the HAProxy charm 
+  Implemented the requirer side of the `ddos_protection` interface in the HAProxy charm 
   to enhance DDoS mitigation capabilities.
 urls:
   - https://github.com/canonical/haproxy-operator/pull/323

--- a/docs/release-notes/artifacts/pr0336.yaml
+++ b/docs/release-notes/artifacts/pr0336.yaml
@@ -1,12 +1,17 @@
 version_schema: 2
 
 changes:
-  - title: Removed "assumes juju >= 3.6" for the HAProxy DDoS protection configurator charm.
+  - title: Fixed issues with the DDoS protection configurator charm found in staging.
     author: swetha1654
     type: minor
     description: >
+      Removed "assumes juju >= 3.6" for the HAProxy DDoS protection configurator charm.
       The HAProxy DDoS protection configurator charm works without requiring Juju version 3.6 or 
       higher. This change enhances compatibility with earlier Juju versions.
+
+      Added the `sc` prefix to the `conn_rate` and `conn_cur` options in the HAProxy template.
+
+      Fixed the previous PR's changelog and artifact to accurately reflect requirer instead of provider.
     urls:
       pr:
         - https://github.com/canonical/haproxy-operator/pull/336

--- a/docs/release-notes/artifacts/pr0336.yaml
+++ b/docs/release-notes/artifacts/pr0336.yaml
@@ -1,0 +1,15 @@
+version_schema: 2
+
+changes:
+  - title: Removed "assumes juju >= 3.6" for the HAProxy DDoS protection configurator charm.
+    author: swetha1654
+    type: minor
+    description: >
+      The HAProxy DDoS protection configurator charm works without requiring Juju version 3.6 or 
+      higher. This change enhances compatibility with earlier Juju versions, especially for the
+      HAProxy staging environment that uses Juju version less than 3.6.
+    urls:
+      pr:
+        - https://github.com/canonical/haproxy-operator/pull/336
+    visibility: public
+    highlight: false

--- a/docs/release-notes/artifacts/pr0336.yaml
+++ b/docs/release-notes/artifacts/pr0336.yaml
@@ -6,8 +6,7 @@ changes:
     type: minor
     description: >
       The HAProxy DDoS protection configurator charm works without requiring Juju version 3.6 or 
-      higher. This change enhances compatibility with earlier Juju versions, especially for the
-      HAProxy staging environment that uses Juju version less than 3.6.
+      higher. This change enhances compatibility with earlier Juju versions.
     urls:
       pr:
         - https://github.com/canonical/haproxy-operator/pull/336

--- a/haproxy-ddos-protection-configurator/charmcraft.yaml
+++ b/haproxy-ddos-protection-configurator/charmcraft.yaml
@@ -34,9 +34,6 @@ links:
   contact:
   - https://launchpad.net/~canonical-is-devops
 
-assumes:
-- juju >= 3.6
-
 config:
   options:
     rate-limit-requests-per-minute:

--- a/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
@@ -34,10 +34,10 @@ frontend {{ endpoint.name }}
 {% if ddos_protection_config.has_rate_limiting %}
     tcp-request connection track-sc0 src table haproxy_peers/ddos_protection_ip
 {% if ddos_protection_config.rate_limit_connections_per_minute %}
-    tcp-request connection {{ ddos_protection_config.limit_policy_tcp }} if { conn_rate(0,haproxy_peers/ddos_protection_ip) gt {{ ddos_protection_config.rate_limit_connections_per_minute }} }
+    tcp-request connection {{ ddos_protection_config.limit_policy_tcp }} if { sc_conn_rate(0,haproxy_peers/ddos_protection_ip) gt {{ ddos_protection_config.rate_limit_connections_per_minute }} }
 {% endif %}
 {% if ddos_protection_config.concurrent_connections_limit %}
-    tcp-request connection {{ ddos_protection_config.limit_policy_tcp }} if { conn_cur(0,haproxy_peers/ddos_protection_ip) gt {{ ddos_protection_config.concurrent_connections_limit }} }
+    tcp-request connection {{ ddos_protection_config.limit_policy_tcp }} if { sc_conn_cur(0,haproxy_peers/ddos_protection_ip) gt {{ ddos_protection_config.concurrent_connections_limit }} }
 {% endif %}
 {% endif %}
 {% if ddos_protection_config.ip_allow_list %}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Removed "assumes juju >= 3.6" for the HAProxy DDoS protection configurator charm.
The HAProxy DDoS protection configurator charm works without requiring Juju version 3.6 or 
higher. This change enhances compatibility with earlier Juju versions.

Added the `sc` prefix to the `conn_rate` and `conn_cur` options in the HAProxy template.

Fixed the previous PR's changelog and artifact to accurately reflect requirer instead of provider.

### Rationale

<!-- The reason the change is needed -->
HAProxy staging environment currently uses Juju controller 3.5.x. This is causing the terraform deployment to fail as the DDoS configurator requires Juju > 3.6. This is not a requirement and it can be removed.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
