### PR TITLE
add release artifact for haproxy rev 290

### DIFF
--- a/docs/release-notes/releases/release0002.yaml
+++ b/docs/release-notes/releases/release0002.yaml
@@ -1,4 +1,7 @@
 # --- Information about release ----
+version_schema: 2
+
+workload_with_version: HAProxy 2.8
 
 # list of change artifacts included in the release
 included_changes:
@@ -10,9 +13,3 @@ earliest_revision: 284
 
 # latest revision included in the release
 latest_revision: 290
-
-# earliest date included in the release
-earliest_date: 2025-12-10
-
-# latest date included in the release 
-latest_date: 2025-12-16

--- a/docs/release-notes/releases/release0002.yaml
+++ b/docs/release-notes/releases/release0002.yaml
@@ -1,0 +1,18 @@
+# --- Information about release ----
+
+# list of change artifacts included in the release
+included_changes:
+  - pr0279.yaml
+  - pr0284.yaml
+
+# earliest revision included in the release
+earliest_revision: 284
+
+# latest revision included in the release
+latest_revision: 290
+
+# earliest date included in the release
+earliest_date: 2025-12-10
+
+# latest date included in the release 
+latest_date: 2025-12-16

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,10 +3,10 @@ canonical-sphinx==0.5.2
 
 # Extensions previously auto-loaded by canonical-sphinx
 myst-parser==4.0.1
-sphinx-autobuild==2025.8.25
+sphinx-autobuild==2024.10.3
 sphinx-design==0.6.1
 sphinx-notfound-page==1.1.0
-sphinx-reredirects==1.1.0
+sphinx-reredirects==0.1.6
 sphinx-tabs==3.4.7
 sphinxcontrib-jquery==4.1
 sphinxext-opengraph==0.13.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ canonical-sphinx==0.5.2
 
 # Extensions previously auto-loaded by canonical-sphinx
 myst-parser==4.0.1
-sphinx-autobuild==2024.10.3
+sphinx-autobuild==2025.8.25
 sphinx-design==0.6.1
 sphinx-notfound-page==1.1.0
 sphinx-reredirects==1.1.0


### PR DESCRIPTION
Release artifact for haproxy rev 290 on latest/stable

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
