### PR TITLE
Revert "chore(deps): update dependency sphinx-autobuild to v2025 (#333)"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ myst-parser==4.0.1
 sphinx-autobuild==2024.10.3
 sphinx-design==0.6.1
 sphinx-notfound-page==1.1.0
-sphinx-reredirects==1.1.0
+sphinx-reredirects==0.1.6
 sphinx-tabs==3.4.7
 sphinxcontrib-jquery==4.1
 sphinxext-opengraph==0.13.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ canonical-sphinx==0.5.2
 
 # Extensions previously auto-loaded by canonical-sphinx
 myst-parser==4.0.1
-sphinx-autobuild==2025.8.25
+sphinx-autobuild==2024.10.3
 sphinx-design==0.6.1
 sphinx-notfound-page==1.1.0
 sphinx-reredirects==1.1.0


### PR DESCRIPTION
This reverts commit 5c3279b86729cfc8a77e2319acc2f39d7c1648f0. Sphix-autobuild v2025 requires python 3.11 which is not yet configurable in the documentation workflows. ref: https://github.com/canonical/sphinx-docs-starter-pack/pull/503

This PR also reverts the sphinx-redirect bump to v1

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
