### PR TITLE
Refactor ingress_per_unit integration test

### DIFF
--- a/haproxy-operator/tests/integration/conftest.py
+++ b/haproxy-operator/tests/integration/conftest.py
@@ -210,15 +210,6 @@ def any_charm_ingress_per_unit_requirer_fixture(
         lambda status: (jubilant.all_active(status, ANY_CHARM_INGRESS_PER_UNIT_REQUIRER)),
         timeout=JUJU_WAIT_TIMEOUT,
     )
-    juju.integrate(
-        f"{configured_application_with_tls}:ingress-per-unit",
-        f"{ANY_CHARM_INGRESS_PER_UNIT_REQUIRER}:require-ingress-per-unit",
-    )
-    juju.wait(
-        lambda status: jubilant.all_active(
-            status, configured_application_with_tls, ANY_CHARM_INGRESS_PER_UNIT_REQUIRER
-        )
-    )
     return ANY_CHARM_INGRESS_PER_UNIT_REQUIRER
 
 

--- a/haproxy-operator/tests/integration/test_ingress_per_unit.py
+++ b/haproxy-operator/tests/integration/test_ingress_per_unit.py
@@ -35,12 +35,12 @@ async def test_ingress_per_unit_integration(
         )
     )
     unit_ip = get_unit_ip_address(juju, configured_application_with_tls)
-    path_suffix = f"{juju.model}-{any_charm_ingress_per_unit_requirer}/0/ok"
+    path = f"{juju.model}-{any_charm_ingress_per_unit_requirer}/0/ok"
 
     if isinstance(unit_ip, ipaddress.IPv6Address):
-        ingress_url = f"https://[{unit_ip}]{path_suffix}"
+        ingress_url = f"https://[{unit_ip}]/{path}"
     else:
-        ingress_url = f"https://{unit_ip}{path_suffix}"
+        ingress_url = f"https://{unit_ip}/{path}"
 
     response = requests.get(
         ingress_url,


### PR DESCRIPTION
reduce flakiness by avoid reading the relation data and move away from using DNSresolver

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
