### PR TITLE
Remove unused external_grpc_port from Server class

### DIFF
--- a/haproxy-operator/src/state/haproxy_route.py
+++ b/haproxy-operator/src/state/haproxy_route.py
@@ -48,7 +48,6 @@ class HAProxyRouteServer:
         protocol: The protocol that the backend service speaks. "http" (default) or "https".
         check: Health check configuration.
         maxconn: Maximum allowed connections before requests are queued.
-        external_grpc_port: Optional external gRPC port.
     """
 
     server_name: str
@@ -57,7 +56,6 @@ class HAProxyRouteServer:
     protocol: str
     check: Optional[ServerHealthCheck]
     maxconn: Optional[int]
-    external_grpc_port: Optional[int]
 
 
 @dataclass(frozen=True)
@@ -466,7 +464,6 @@ def get_servers_definition_from_requirer_data(
                     protocol=requirer.application_data.protocol,
                     check=requirer.application_data.check,
                     maxconn=requirer.application_data.server_maxconn,
-                    external_grpc_port=requirer.application_data.external_grpc_port,
                 )
             )
     return servers


### PR DESCRIPTION
The `external_grpc_port` attribute of the `Server` class is not used to render the haproxy template. The attribute also shouldn't belong to the `Server` class since it's tied to each backend

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is updated
- [ ] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
