### PR TITLE
Add release artifact for rev 314 stable release

### DIFF
--- a/docs/release-notes/releases/release0003.yaml
+++ b/docs/release-notes/releases/release0003.yaml
@@ -1,0 +1,28 @@
+# --- Information about release ----
+version_schema: 2
+
+workload_with_version: HAProxy 2.8
+
+# list of change artifacts included in the release
+included_changes:
+  - pr0287.yaml
+  - pr0299.yaml
+  - pr0300.yaml
+  - pr0302.yaml
+  - pr0315.yaml
+  - pr0316.yaml
+  - pr0317.yaml
+  - pr0318.yaml
+  - pr0319.yaml
+  - pr0321.yaml
+  - pr0323.yaml
+  - pr0324.yaml
+  - pr0325.yaml
+  - pr0328.yaml
+  - pr0329.yaml
+
+# earliest revision included in the release
+earliest_revision: 293
+
+# latest revision included in the release
+latest_revision: 314


### PR DESCRIPTION

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
