### PR TITLE
update handling for multiple CA relations

### DIFF
--- a/docs/release-notes/artifacts/pr0358.yaml
+++ b/docs/release-notes/artifacts/pr0358.yaml
@@ -1,0 +1,15 @@
+version_schema: 2
+
+changes:
+  - title: Fix remove ca certificate relation where there are still ca certificates.
+    author: alexdlukens
+    type: minor
+    description: >
+      Instead of removing the cas.pem file when removing a CA relation, call the update_trusted_cas() method.
+      Update the update_trusted_cas() method to check if all CAs have been removed.
+    urls:
+      pr:
+        - https://github.com/canonical/haproxy-operator/pull/358
+      related_issue: https://github.com/canonical/haproxy-operator/issues/357
+    visibility: public
+    highlight: false

--- a/haproxy-operator/src/charm.py
+++ b/haproxy-operator/src/charm.py
@@ -486,7 +486,7 @@ class HAProxyCharm(ops.CharmBase):
     @validate_config_and_tls(defer=True)
     def _on_ca_certificates_removed(self, _: CertificatesRemovedEvent) -> None:
         """Handle the CA certificates removed event."""
-        self._tls.remove_cas_from_unit()
+        self._tls.update_trusted_cas()
         self._reconcile()
 
     @validate_config_and_tls(defer=False)

--- a/haproxy-operator/src/tls_relation.py
+++ b/haproxy-operator/src/tls_relation.py
@@ -96,7 +96,12 @@ class TLSRelationService:
 
     def update_trusted_cas(self) -> None:
         """Handle the change in the set of CAs to trust."""
-        self.write_cas_to_unit(self.recv_ca_cert.get_all_certificates())
+        ca_certificates = self.recv_ca_cert.get_all_certificates()
+        if not ca_certificates:
+            logger.info("No CA certificates found, removing existing CA bundle")
+            self.remove_cas_from_unit()
+            return
+        self.write_cas_to_unit(ca_certificates)
 
     def _certificate_matches_stored_content(
         self, certificate: Certificate, chain: list[Certificate], private_key: PrivateKey

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -225,28 +225,21 @@ def deploy_iam_bundle_fixture(k8s_juju: jubilant.Juju):
         logger.info("identity-platform is already deployed")
         return
     k8s_juju.deploy(
-        "self-signed-certificates", channel="latest/stable", revision=155, trust=True
+        "self-signed-certificates", channel="1/stable", revision=317, trust=True
     )
-    k8s_juju.deploy("hydra", channel="latest/stable", revision=362, trust=True)
-    k8s_juju.deploy("kratos", channel="latest/stable", revision=527, trust=True)
+    k8s_juju.deploy("hydra", channel="latest/edge", revision=399, trust=True)
+    k8s_juju.deploy("kratos", channel="latest/edge", revision=567, trust=True)
     k8s_juju.deploy(
         "identity-platform-login-ui-operator",
-        channel="latest/stable",
-        revision=166,
-        trust=True,
-    )
-    k8s_juju.deploy(
-        "traefik-k8s",
-        "traefik-admin",
-        channel="latest/stable",
-        revision=176,
+        channel="latest/edge",
+        revision=200,
         trust=True,
     )
     k8s_juju.deploy(
         "traefik-k8s",
         "traefik-public",
-        channel="latest/stable",
-        revision=176,
+        channel="latest/edge",
+        revision=270,
         trust=True,
     )
     k8s_juju.deploy(
@@ -279,17 +272,12 @@ def deploy_iam_bundle_fixture(k8s_juju: jubilant.Juju):
     k8s_juju.integrate("postgresql-k8s:database", "hydra:pg-database")
     k8s_juju.integrate("postgresql-k8s:database", "kratos:pg-database")
     k8s_juju.integrate(
-        "self-signed-certificates:certificates", "traefik-admin:certificates"
-    )
-    k8s_juju.integrate(
         "self-signed-certificates:certificates", "traefik-public:certificates"
     )
-    k8s_juju.integrate("traefik-admin:ingress", "hydra:admin-ingress")
-    k8s_juju.integrate("traefik-admin:ingress", "kratos:admin-ingress")
-    k8s_juju.integrate("traefik-public:ingress", "hydra:public-ingress")
-    k8s_juju.integrate("traefik-public:ingress", "kratos:public-ingress")
+    k8s_juju.integrate("traefik-public:traefik-route", "hydra:public-route")
+    k8s_juju.integrate("traefik-public:traefik-route", "kratos:public-route")
     k8s_juju.integrate(
-        "traefik-public:ingress", "identity-platform-login-ui-operator:ingress"
+        "traefik-public:traefik-route", "identity-platform-login-ui-operator:public-route"
     )
 
     k8s_juju.config("kratos", {"enforce_mfa": False})


### PR DESCRIPTION

### Overview

Fixes https://github.com/canonical/haproxy-operator/issues/357

- instead of removing the cas.pem file when removing a CA relation, call the `update_trusted_cas()` method. Update the `update_trusted_cas()` method to check if all CAs have been removed.

### Rationale

Removing a CA when there is more than 1 CA relation is currently broken

### Juju Events Changes

update `_on_ca_certificates_removed` and `_on_ca_certificates_updated` functionality to support adding/removing several CAs

