### PR TITLE
fix: add proper type to hosts in haproxy libraries

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-04-01
+
+- Fixed hosts validation in haproxy-route and haproxy-route-tcp relation libraries.
+
 ## 2026-01-19
 
 - Fixed issues with the DDoS protection configurator charm found in staging.

--- a/docs/release-notes/artifacts/pr0383.yaml
+++ b/docs/release-notes/artifacts/pr0383.yaml
@@ -1,0 +1,13 @@
+version_schema: 2
+changes:
+  - title: Fix hosts validation in haproxy-route-tcp, and haproxy-route relation libraries
+    author: skatsaounis
+    type: bugfix
+    description: >
+      Fixed hosts validation in the haproxy-route-tcp and haproxy-route relation libraries, ensuring
+      that only valid IP addresses are accepted.
+    urls:
+      pr:
+        - https://github.com/canonical/haproxy-operator/pull/383
+    visibility: public
+    highlight: false

--- a/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -186,7 +186,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
@@ -976,7 +976,7 @@ class HaproxyRouteTcpRequirer(Object):
         *,
         port: Optional[int] = None,
         backend_port: Optional[int] = None,
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
         check_interval: Optional[int] = None,
         check_rise: Optional[int] = None,
@@ -1102,7 +1102,7 @@ class HaproxyRouteTcpRequirer(Object):
         *,
         port: int,
         backend_port: Optional[int] = None,
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
         check_interval: Optional[int] = None,
         check_rise: Optional[int] = None,
@@ -1200,7 +1200,7 @@ class HaproxyRouteTcpRequirer(Object):
         *,
         port: Optional[int] = None,
         backend_port: Optional[int] = None,
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
         check_interval: Optional[int] = None,
         check_rise: Optional[int] = None,
@@ -1558,7 +1558,7 @@ class HaproxyRouteTcpRequirer(Object):
         self._application_data["backend_port"] = backend_port
         return self
 
-    def configure_hosts(self, hosts: Optional[list[int]] = None) -> "Self":
+    def configure_hosts(self, hosts: Optional[list[IPvAnyAddress]] = None) -> "Self":
         """Set backend hosts.
 
         Args:

--- a/haproxy-operator/lib/charms/haproxy/v2/haproxy_route.py
+++ b/haproxy-operator/lib/charms/haproxy/v2/haproxy_route.py
@@ -154,7 +154,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
@@ -1005,7 +1005,7 @@ class HaproxyRouteRequirer(Object):
         service: Optional[str] = None,
         ports: Optional[list[int]] = None,
         protocol: Literal["http", "https"] = "http",
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         paths: Optional[list[str]] = None,
         hostname: Optional[str] = None,
         additional_hostnames: Optional[list[str]] = None,
@@ -1144,7 +1144,7 @@ class HaproxyRouteRequirer(Object):
         service: str,
         ports: list[int],
         protocol: Literal["http", "https"] = "http",
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         paths: Optional[list[str]] = None,
         hostname: Optional[str] = None,
         additional_hostnames: Optional[list[str]] = None,
@@ -1258,7 +1258,7 @@ class HaproxyRouteRequirer(Object):
         service: Optional[str] = None,
         ports: Optional[list[int]] = None,
         protocol: Literal["http", "https"] = "http",
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         paths: Optional[list[str]] = None,
         hostname: Optional[str] = None,
         additional_hostnames: Optional[list[str]] = None,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
