### PR TITLE
ISD-5155 correctly publish proxied endpoint for haproxy-route-tcp

### DIFF
--- a/docs/release-notes/artifacts/pr0384.yaml
+++ b/docs/release-notes/artifacts/pr0384.yaml
@@ -1,0 +1,16 @@
+version_schema: 2
+
+changes:
+  - title: Publish proxied endpoints for haproxy-route-tcp frontends
+    author: tphan025
+    type: minor
+    description: >
+      Added publishing of proxied endpoints for haproxy-route-tcp relations.
+      For SNI-enabled frontends, endpoints are published as "<sni>:<port>".
+      For non-SNI frontends, endpoints use the HA VIP when available or fallback to peer unit
+      addresses. The haproxy-route-tcp library now uses string endpoints instead of AnyUrl.
+    urls:
+      pr:
+        - https://github.com/canonical/haproxy-operator/pull/384
+    visibility: public
+    highlight: false

--- a/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -166,7 +166,6 @@ from ops.charm import CharmEvents
 from ops.framework import EventBase, EventSource, Object
 from ops.model import Relation
 from pydantic import (
-    AnyUrl,
     BaseModel,
     BeforeValidator,
     ConfigDict,
@@ -187,7 +186,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
@@ -690,7 +689,7 @@ class HaproxyRouteTcpProviderAppData(_DatabagModel):
         endpoints: The list of proxied endpoints that maps to the backend.
     """
 
-    endpoints: list[AnyUrl]
+    endpoints: list[str]
 
 
 class TcpRequirerUnitData(_DatabagModel):
@@ -935,9 +934,9 @@ class HaproxyRouteTcpProvider(Object):
             endpoints: The list of proxied endpoints to publish.
             relation: The relation with the requirer application.
         """
-        HaproxyRouteTcpProviderAppData(
-            endpoints=[cast(AnyUrl, endpoint) for endpoint in endpoints]
-        ).dump(relation.data[self.charm.app], clear=True)
+        HaproxyRouteTcpProviderAppData(endpoints=endpoints).dump(
+            relation.data[self.charm.app], clear=True
+        )
 
 
 class HaproxyRouteTcpEnpointsReadyEvent(EventBase):
@@ -1505,7 +1504,7 @@ class HaproxyRouteTcpRequirer(Object):
                 raise DataValidationError("No unit IP available.")
         return TcpRequirerUnitData(address=cast(IPvAnyAddress, address))
 
-    def get_proxied_endpoints(self) -> list[AnyUrl]:
+    def get_proxied_endpoints(self) -> list[str]:
         """The full ingress URL to reach the current unit.
 
         Returns:

--- a/haproxy-operator/src/charm.py
+++ b/haproxy-operator/src/charm.py
@@ -77,6 +77,7 @@ REVERSE_PROXY_RELATION = "reverseproxy"
 WEBSITE_RELATION = "website"
 RECV_CA_CERTS_RELATION = "receive-ca-certs"
 SPOE_AUTH_RELATION = "spoe-auth"
+HAPROXY_ROUTE_TCP_RELATION = "haproxy-route-tcp"
 
 
 class HaproxyUnitAddressNotAvailableError(CharmStateValidationBaseError):
@@ -288,7 +289,7 @@ class HAProxyCharm(ops.CharmBase):
             case ProxyMode.LEGACY:
                 self._configure_legacy(charm_state)
             case ProxyMode.HAPROXY_ROUTE:
-                self._configure_haproxy_route(charm_state)
+                self._configure_haproxy_route(charm_state, ha_information)
             case _:
                 if self.model.get_relation(TLS_CERT_RELATION):
                     # Reconcile certificates in case the certificates relation is present
@@ -351,7 +352,9 @@ class HAProxyCharm(ops.CharmBase):
             charm_state, self.reverseproxy_requirer.get_services()
         )
 
-    def _configure_haproxy_route(self, charm_state: CharmState) -> None:
+    def _configure_haproxy_route(
+        self, charm_state: CharmState, ha_information: HAInformation
+    ) -> None:
         """Configure the haproxy route relation."""
         haproxy_route_requirers_information = HaproxyRouteRequirersInformation.from_provider(
             haproxy_route=self.haproxy_route_provider,
@@ -414,6 +417,34 @@ class HAProxyCharm(ops.CharmBase):
             for relation_id in haproxy_route_requirers_information.relation_ids_with_invalid_data:
                 if relation := self.model.get_relation(HAPROXY_ROUTE_RELATION, relation_id):
                     self.haproxy_route_provider.publish_proxied_endpoints([], relation)
+
+            for frontend in haproxy_route_requirers_information.valid_tcp_frontends():
+                for backend in frontend.backends:
+                    relation = self.model.get_relation(
+                        HAPROXY_ROUTE_TCP_RELATION, backend.relation_id
+                    )
+                    if not relation:
+                        logger.error(
+                            "The haproxy-route-tcp relation does not exist for this backend, skipping."
+                        )
+                        continue
+                    if frontend.is_sni_routing_enabled:
+                        self.haproxy_route_tcp_provider.publish_proxied_endpoints(
+                            [f"{backend.application_data.sni}:{frontend.port}"], relation
+                        )
+                        continue
+                    if ha_information.ha_integration_ready:
+                        self.haproxy_route_tcp_provider.publish_proxied_endpoints(
+                            [f"{ha_information.vip}:{frontend.port}"], relation
+                        )
+                        continue
+                    self.haproxy_route_tcp_provider.publish_proxied_endpoints(
+                        [
+                            f"{unit_address}:{frontend.port}"
+                            for unit_address in self._get_peer_units_address()
+                        ],
+                        relation,
+                    )
 
     def _get_certificate_requests(self) -> typing.List[CertificateRequestAttributes]:
         """Get the certificate requests.

--- a/haproxy-operator/src/charm.py
+++ b/haproxy-operator/src/charm.py
@@ -403,48 +403,10 @@ class HAProxyCharm(ops.CharmBase):
             ),
         )
         if self.unit.is_leader():
-            for backend in haproxy_route_requirers_information.backends:
-                relation = self.model.get_relation(HAPROXY_ROUTE_RELATION, backend.relation_id)
-                if not relation:
-                    logger.error(
-                        "The haproxy-route relation does not exist for this backend, skipping."
-                    )
-                    continue
-                self.haproxy_route_provider.publish_proxied_endpoints(
-                    self._get_backend_proxied_endpoints(backend),
-                    relation,
-                )
-            for relation_id in haproxy_route_requirers_information.relation_ids_with_invalid_data:
-                if relation := self.model.get_relation(HAPROXY_ROUTE_RELATION, relation_id):
-                    self.haproxy_route_provider.publish_proxied_endpoints([], relation)
-
-            for frontend in haproxy_route_requirers_information.valid_tcp_frontends():
-                for backend in frontend.backends:
-                    relation = self.model.get_relation(
-                        HAPROXY_ROUTE_TCP_RELATION, backend.relation_id
-                    )
-                    if not relation:
-                        logger.error(
-                            "The haproxy-route-tcp relation does not exist for this backend, skipping."
-                        )
-                        continue
-                    if frontend.is_sni_routing_enabled:
-                        self.haproxy_route_tcp_provider.publish_proxied_endpoints(
-                            [f"{backend.application_data.sni}:{frontend.port}"], relation
-                        )
-                        continue
-                    if ha_information.ha_integration_ready:
-                        self.haproxy_route_tcp_provider.publish_proxied_endpoints(
-                            [f"{ha_information.vip}:{frontend.port}"], relation
-                        )
-                        continue
-                    self.haproxy_route_tcp_provider.publish_proxied_endpoints(
-                        [
-                            f"{unit_address}:{frontend.port}"
-                            for unit_address in self._get_peer_units_address()
-                        ],
-                        relation,
-                    )
+            self._publish_haproxy_route_proxied_endpoints(haproxy_route_requirers_information)
+            self._publish_haproxy_route_tcp_proxied_endpoints(
+                haproxy_route_requirers_information, ha_information
+            )
 
     def _get_certificate_requests(self) -> typing.List[CertificateRequestAttributes]:
         """Get the certificate requests.
@@ -677,6 +639,57 @@ class HAProxyCharm(ops.CharmBase):
         ]
 
         event.set_results({"endpoints": json.dumps(proxied_endpoints)})
+
+    def _publish_haproxy_route_proxied_endpoints(
+        self, haproxy_route_requirers_information: HaproxyRouteRequirersInformation
+    ) -> None:
+        """Publish the proxied endpoints for HTTP frontends."""
+        for backend in haproxy_route_requirers_information.backends:
+            relation = self.model.get_relation(HAPROXY_ROUTE_RELATION, backend.relation_id)
+            if not relation:
+                logger.error(
+                    "The haproxy-route relation does not exist for this backend, skipping."
+                )
+                continue
+            self.haproxy_route_provider.publish_proxied_endpoints(
+                self._get_backend_proxied_endpoints(backend),
+                relation,
+            )
+        for relation_id in haproxy_route_requirers_information.relation_ids_with_invalid_data:
+            if relation := self.model.get_relation(HAPROXY_ROUTE_RELATION, relation_id):
+                self.haproxy_route_provider.publish_proxied_endpoints([], relation)
+
+    def _publish_haproxy_route_tcp_proxied_endpoints(
+        self,
+        haproxy_route_requirers_information: HaproxyRouteRequirersInformation,
+        ha_information: HAInformation,
+    ) -> None:
+        """Publish the proxied endpoints for TCP frontends."""
+        for frontend in haproxy_route_requirers_information.valid_tcp_frontends():
+            for backend in frontend.backends:
+                relation = self.model.get_relation(HAPROXY_ROUTE_TCP_RELATION, backend.relation_id)
+                if not relation:
+                    logger.error(
+                        "The haproxy-route-tcp relation does not exist for this backend, skipping."
+                    )
+                    continue
+                if frontend.is_sni_routing_enabled:
+                    self.haproxy_route_tcp_provider.publish_proxied_endpoints(
+                        [f"{backend.application_data.sni}:{frontend.port}"], relation
+                    )
+                    continue
+                if ha_information.ha_integration_ready:
+                    self.haproxy_route_tcp_provider.publish_proxied_endpoints(
+                        [f"{ha_information.vip}:{frontend.port}"], relation
+                    )
+                    continue
+                self.haproxy_route_tcp_provider.publish_proxied_endpoints(
+                    [
+                        f"{unit_address}:{frontend.port}"
+                        for unit_address in self._get_peer_units_address()
+                    ],
+                    relation,
+                )
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/haproxy-operator/tests/unit/conftest.py
+++ b/haproxy-operator/tests/unit/conftest.py
@@ -433,6 +433,69 @@ def mock_out_validate_global_max_conn_check(monkeypatch):
     )
 
 
+@pytest.fixture(name="tcp_reconcile_context")
+def tcp_reconcile_context_fixture():
+    """Context fixture that mocks haproxy reconciliation but allows publish_proxied_endpoints.
+
+    Yields:
+        Tuple of (Context, get_unit_address_mock).
+    """
+    with (
+        patch("haproxy.HAProxyService.reconcile_haproxy_route"),
+        patch("tls_relation.TLSRelationService.write_certificate_to_unit"),
+        patch("charm.HAProxyCharm._get_unit_address") as get_unit_address_mock,
+        patch("haproxy.HAProxyService.install"),
+    ):
+        get_unit_address_mock.return_value = "10.0.0.1"
+        yield (
+            Context(
+                charm_type=HAProxyCharm,
+            ),
+            get_unit_address_mock,
+        )
+
+
+def build_haproxy_route_tcp_relation(
+    *,
+    port: int = 4000,
+    backend_port: int | None = None,
+    sni: str | None = None,
+    enforce_tls: bool = True,
+    tls_terminate: bool = False,
+    remote_app_name: str = "tcp-requirer",
+) -> scenario.Relation:
+    """Build a scenario Relation for haproxy-route-tcp.
+
+    Args:
+        port: Frontend port.
+        backend_port: Backend port (defaults to port).
+        sni: Server Name Indication value.
+        enforce_tls: Whether to enforce TLS.
+        tls_terminate: Whether to terminate TLS.
+        remote_app_name: Remote application name.
+
+    Returns:
+        A scenario Relation for haproxy-route-tcp.
+    """
+    app_data: dict[str, str | int | bool | None] = {
+        "port": port,
+        "enforce_tls": enforce_tls,
+        "tls_terminate": tls_terminate,
+    }
+    if backend_port is not None:
+        app_data["backend_port"] = backend_port
+    if sni is not None:
+        app_data["sni"] = sni
+
+    return scenario.Relation(
+        endpoint="haproxy-route-tcp",
+        interface="haproxy-route-tcp",
+        remote_app_name=remote_app_name,
+        remote_app_data=TcpRequirerApplicationData.from_dict(app_data).dump(),
+        remote_units_data={0: TcpRequirerUnitData.from_dict({"address": "10.0.0.1"}).dump()},
+    )
+
+
 @pytest.fixture(scope="module", name="haproxy_route_tcp_relation_data")
 def haproxy_route_tcp_relation_data_fixture() -> typing.Callable[..., HaproxyRouteTcpRequirerData]:
     """Get haproxy-route-tcp relation data generator."""

--- a/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
@@ -20,7 +20,7 @@ from charms.haproxy.v1.haproxy_route_tcp import (
     TcpRequirerUnitData,
     TCPServerHealthCheck,
 )
-from pydantic import AnyHttpUrl, ValidationError
+from pydantic import ValidationError
 
 logger = logging.getLogger()
 MOCK_RELATION_NAME = "haproxy-route-tcp"
@@ -52,9 +52,7 @@ def mock_unit_data_fixture():
 @pytest.fixture(name="mock_provider_app_data")
 def mock_provider_app_data_fixture():
     """Create mock provider app data."""
-    return HaproxyRouteTcpProviderAppData(
-        endpoints=[cast(AnyHttpUrl, "https://backend.haproxy.internal:8080")]
-    ).dump()
+    return HaproxyRouteTcpProviderAppData(endpoints=["backend.haproxy.internal:8080"]).dump()
 
 
 # pylint: disable=no-member
@@ -181,18 +179,6 @@ def test_requirer_unit_data_validation():
     assert str(data.address) == str(MOCK_ADDRESS)
 
 
-def test_provider_app_data_validation():
-    """
-    arrange: Create a HaproxyRouteTcpProviderAppData model with valid data.
-    act: Validate the model.
-    assert: Model validation passes.
-    """
-    data = HaproxyRouteTcpProviderAppData(endpoints=[cast(AnyHttpUrl, "https://example.com:8080")])
-    # Note: pydantic automatically adds a trailing slash '/'
-    # after validating the URL, this is intended behavior
-    assert [str(endpoint) for endpoint in data.endpoints] == ["https://example.com:8080/"]
-
-
 def test_tcp_requirers_data_duplicate_ports():
     """
     arrange: Create HaproxyRouteTcpRequirersData with duplicate port numbers.
@@ -316,16 +302,6 @@ def test_dump_requirer_unit_data():
     assert json.loads(databag["address"]) == str(MOCK_ADDRESS)
 
 
-def test_get_proxied_endpoints_with_valid_data(mock_provider_app_data):
-    """Test that endpoints can be loaded from valid provider data."""
-    provider_data = cast(
-        HaproxyRouteTcpProviderAppData, HaproxyRouteTcpProviderAppData.load(mock_provider_app_data)
-    )
-
-    assert len(provider_data.endpoints) == 1
-    assert str(provider_data.endpoints[0]) == "https://backend.haproxy.internal:8080/"
-
-
 def test_get_proxied_endpoints_empty_data():
     """Test that HaproxyRouteTcpProviderAppData handles empty endpoints."""
     provider_data = HaproxyRouteTcpProviderAppData(endpoints=[])
@@ -333,10 +309,10 @@ def test_get_proxied_endpoints_empty_data():
     assert provider_data.endpoints == []
 
 
-def test_get_proxied_endpoints_invalid_data():
-    """Test that HaproxyRouteTcpProviderAppData validation fails with invalid URLs."""
-    with pytest.raises(ValidationError):
-        HaproxyRouteTcpProviderAppData(endpoints=[cast(AnyHttpUrl, "invalid")])
+def test_get_proxied_endpoints_accepts_plain_strings():
+    """Test that HaproxyRouteTcpProviderAppData accepts plain string endpoints."""
+    data = HaproxyRouteTcpProviderAppData(endpoints=["10.0.0.1:8080", "api.example.com:443"])
+    assert data.endpoints == ["10.0.0.1:8080", "api.example.com:443"]
 
 
 def test_tcp_health_check_types():

--- a/haproxy-operator/tests/unit/test_haproxy_route_tcp_proxied_endpoints.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_tcp_proxied_endpoints.py
@@ -1,0 +1,295 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for publishing proxied endpoints to haproxy-route-tcp relation data."""
+
+import json
+
+import ops
+import ops.testing
+import pytest
+
+from .conftest import build_haproxy_route_tcp_relation
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_sni_routing(tcp_reconcile_context, peer_relation) -> None:
+    """
+    arrange: Create a haproxy-route-tcp relation with SNI configured.
+    act: Trigger config_changed as leader.
+    assert: Proxied endpoints are published as "{sni}:{port}" in the relation data.
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port=4000,
+        sni="api.example.com",
+        enforce_tls=True,
+        tls_terminate=False,
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation],
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
+    assert endpoints == ["api.example.com:4000"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_sni_routing_multiple_backends(
+    tcp_reconcile_context, peer_relation
+) -> None:
+    """
+    arrange: Create two haproxy-route-tcp relations with SNI on the same port.
+    act: Trigger config_changed as leader.
+    assert: Each relation gets its own SNI-based endpoint published.
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation_1 = build_haproxy_route_tcp_relation(
+        port=4000,
+        sni="api1.example.com",
+        enforce_tls=True,
+        tls_terminate=False,
+        remote_app_name="tcp-requirer-1",
+    )
+    tcp_relation_2 = build_haproxy_route_tcp_relation(
+        port=4000,
+        sni="api2.example.com",
+        enforce_tls=True,
+        tls_terminate=False,
+        remote_app_name="tcp-requirer-2",
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation_1, tcp_relation_2],
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation_1 = out.get_relation(tcp_relation_1.id)
+    endpoints_1 = json.loads(out_tcp_relation_1.local_app_data["endpoints"])
+    assert endpoints_1 == ["api1.example.com:4000"]
+
+    out_tcp_relation_2 = out.get_relation(tcp_relation_2.id)
+    endpoints_2 = json.loads(out_tcp_relation_2.local_app_data["endpoints"])
+    assert endpoints_2 == ["api2.example.com:4000"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_ha_vip(tcp_reconcile_context, peer_relation) -> None:
+    """
+    arrange: Create a haproxy-route-tcp relation without SNI and an HA relation with VIP.
+    act: Trigger config_changed as leader.
+    assert: Proxied endpoints are published as "{vip}:{port}".
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port=5000,
+        enforce_tls=True,
+        tls_terminate=False,
+    )
+    ha_relation = ops.testing.Relation(
+        endpoint="ha",
+        interface="hacluster",
+        remote_app_name="hacluster",
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation, ha_relation],
+        config={"vip": "192.168.1.100"},
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
+    assert endpoints == ["192.168.1.100:5000"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_peer_unit_addresses(
+    tcp_reconcile_context, peer_relation
+) -> None:
+    """
+    arrange: Create a haproxy-route-tcp relation without SNI and without HA.
+    act: Trigger config_changed as leader.
+    assert: Proxied endpoints are published as "{unit_address}:{port}" for each peer.
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port=6000,
+        enforce_tls=True,
+        tls_terminate=False,
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation],
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
+    assert endpoints == ["10.0.0.1:6000"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_not_leader(tcp_reconcile_context, peer_relation) -> None:
+    """
+    arrange: Create a haproxy-route-tcp relation with valid data.
+    act: Trigger config_changed as a non-leader unit.
+    assert: No proxied endpoints are written to the relation data.
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port=4000,
+        sni="api.example.com",
+        enforce_tls=True,
+        tls_terminate=False,
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation],
+        leader=False,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    assert "endpoints" not in out_tcp_relation.local_app_data
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_sni_with_different_ports(
+    tcp_reconcile_context, peer_relation
+) -> None:
+    """
+    arrange: Create two TCP relations with SNI on different ports.
+    act: Trigger config_changed as leader.
+    assert: Each relation gets its own SNI:port endpoint.
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation_1 = build_haproxy_route_tcp_relation(
+        port=4000,
+        sni="api.example.com",
+        enforce_tls=True,
+        tls_terminate=False,
+        remote_app_name="tcp-requirer-1",
+    )
+    tcp_relation_2 = build_haproxy_route_tcp_relation(
+        port=5000,
+        sni="web.example.com",
+        enforce_tls=True,
+        tls_terminate=False,
+        remote_app_name="tcp-requirer-2",
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation_1, tcp_relation_2],
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation_1 = out.get_relation(tcp_relation_1.id)
+    endpoints_1 = json.loads(out_tcp_relation_1.local_app_data["endpoints"])
+    assert endpoints_1 == ["api.example.com:4000"]
+
+    out_tcp_relation_2 = out.get_relation(tcp_relation_2.id)
+    endpoints_2 = json.loads(out_tcp_relation_2.local_app_data["endpoints"])
+    assert endpoints_2 == ["web.example.com:5000"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_single_backend_no_sni_no_ha(
+    tcp_reconcile_context, peer_relation
+) -> None:
+    """
+    arrange: Create a single TCP relation without SNI routing and without HA.
+    act: Trigger config_changed as leader.
+    assert: Proxied endpoints fall back to peer unit addresses.
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port=8080,
+        enforce_tls=True,
+        tls_terminate=False,
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation],
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
+    assert endpoints == ["10.0.0.1:8080"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_ha_vip_takes_priority_over_peers(
+    tcp_reconcile_context, peer_relation
+) -> None:
+    """
+    arrange: Create a TCP relation without SNI but with HA configured (VIP).
+    act: Trigger config_changed as leader.
+    assert: VIP is used instead of peer unit addresses.
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port=4000,
+        enforce_tls=True,
+        tls_terminate=False,
+    )
+    ha_relation = ops.testing.Relation(
+        endpoint="ha",
+        interface="hacluster",
+        remote_app_name="hacluster",
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation, ha_relation],
+        config={"vip": "10.10.10.10"},
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
+    assert endpoints == ["10.10.10.10:4000"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_sni_takes_priority_over_ha(
+    tcp_reconcile_context, peer_relation
+) -> None:
+    """
+    arrange: Create a TCP relation with both SNI and HA configured.
+    act: Trigger config_changed as leader.
+    assert: SNI endpoint is published, not the VIP.
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port=4000,
+        sni="api.example.com",
+        enforce_tls=True,
+        tls_terminate=False,
+    )
+    ha_relation = ops.testing.Relation(
+        endpoint="ha",
+        interface="hacluster",
+        remote_app_name="hacluster",
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation, ha_relation],
+        config={"vip": "10.10.10.10"},
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
+    assert endpoints == ["api.example.com:4000"]

--- a/haproxy-operator/tests/unit/test_haproxy_route_tcp_proxied_endpoints.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_tcp_proxied_endpoints.py
@@ -110,9 +110,7 @@ def test_tcp_proxied_endpoints_ha_vip(tcp_reconcile_context, peer_relation) -> N
 
 
 @pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
-def test_tcp_proxied_endpoints_peer_unit_addresses(
-    tcp_reconcile_context, peer_relation
-) -> None:
+def test_tcp_proxied_endpoints_peer_unit_addresses(tcp_reconcile_context, peer_relation) -> None:
     """
     arrange: Create a haproxy-route-tcp relation without SNI and without HA.
     act: Trigger config_changed as leader.


### PR DESCRIPTION
Fixes: #365 

Publish proxied endpoint for `haproxy-route-tcp`:
1. If sni routing is configured, publish `<sni>:<frontend_port>` for each backend
2. If (1) is not met, and if VIP is configured, then publish `<vip>:<port>` for each backend
3. Fallback to <unit_ip>:<port> for each backend if both (1) and (2) is not met. Note that this will be a list of IPs if haproxy is deployed with multiple units 

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
