### PR TITLE
disable logging for jubilant

### DIFF
--- a/haproxy-ddos-protection-configurator/tests/integration/conftest.py
+++ b/haproxy-ddos-protection-configurator/tests/integration/conftest.py
@@ -68,5 +68,6 @@ def application_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, charm:
         charm=charm,
         app=app_name,
         base="ubuntu@24.04",
+        log=False,
     )
     return app_name

--- a/haproxy-operator/tests/integration/conftest.py
+++ b/haproxy-operator/tests/integration/conftest.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+from math import log
 import pathlib
 import tempfile
 import typing
@@ -92,6 +93,7 @@ def application_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, charm:
         charm=charm,
         app=app_name,
         base="ubuntu@24.04",
+        log=False,
     )
     return app_name
 
@@ -109,7 +111,10 @@ def certificate_provider_application_fixture(
         logger.warning("Using existing application: %s", SELF_SIGNED_CERTIFICATES_APP_NAME)
         return SELF_SIGNED_CERTIFICATES_APP_NAME
     juju.deploy(
-        "self-signed-certificates", app=SELF_SIGNED_CERTIFICATES_APP_NAME, channel="1/edge"
+        "self-signed-certificates",
+        app=SELF_SIGNED_CERTIFICATES_APP_NAME,
+        channel="1/edge",
+        log=False,
     )
     return SELF_SIGNED_CERTIFICATES_APP_NAME
 
@@ -129,9 +134,7 @@ def configured_application_with_tls_base_fixture(
         f"{application}:certificates", f"{certificate_provider_application}:certificates"
     )
     juju.wait(
-        lambda status: (
-            jubilant.all_active(status, application, certificate_provider_application)
-        ),
+        lambda status: jubilant.all_active(status, application, certificate_provider_application),
         timeout=JUJU_WAIT_TIMEOUT,
     )
     return application
@@ -169,7 +172,7 @@ def configured_application_with_tls_fixture(
             )
     # Ensure the removal is complete otherwise reintegration in next test may fail
     juju.wait(
-        lambda status: (jubilant.all_agents_idle(status)),
+        lambda status: jubilant.all_agents_idle(status),
     )
 
 
@@ -204,10 +207,11 @@ def any_charm_ingress_per_unit_requirer_fixture(
             "python-packages": "pydantic<2.0",
         },
         num_units=2,
+        log=False,
     )
 
     juju.wait(
-        lambda status: (jubilant.all_active(status, ANY_CHARM_INGRESS_PER_UNIT_REQUIRER)),
+        lambda status: jubilant.all_active(status, ANY_CHARM_INGRESS_PER_UNIT_REQUIRER),
         timeout=JUJU_WAIT_TIMEOUT,
     )
     return ANY_CHARM_INGRESS_PER_UNIT_REQUIRER
@@ -259,10 +263,11 @@ def any_charm_haproxy_route_requirer_base_fixture(
                     ]
                 ),
             },
+            log=False,
         )
         juju.wait(
-            lambda status: (
-                jubilant.all_active(status, ANY_CHARM_HAPROXY_ROUTE_REQUIRER_APPLICATION)
+            lambda status: jubilant.all_active(
+                status, ANY_CHARM_HAPROXY_ROUTE_REQUIRER_APPLICATION
             ),
             timeout=JUJU_WAIT_TIMEOUT,
         )
@@ -295,7 +300,7 @@ def any_charm_haproxy_route_requirer_fixture(
             juju.remove_relation(f"{app_name}:{endpoint}", relation.related_app)
 
     juju.wait(
-        lambda status: (jubilant.all_agents_idle(status)),
+        lambda status: jubilant.all_agents_idle(status),
     )
 
 
@@ -324,10 +329,11 @@ def any_charm_haproxy_route_tcp_requirer_base_fixture(
             ),
             "python-packages": "pydantic~=2.10\nvalidators",
         },
+        log=False,
     )
     juju.wait(
-        lambda status: (
-            jubilant.all_active(status, ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION)
+        lambda status: jubilant.all_active(
+            status, ANY_CHARM_HAPROXY_ROUTE_TCP_REQUIRER_APPLICATION
         ),
         timeout=JUJU_WAIT_TIMEOUT,
     )
@@ -359,5 +365,5 @@ def any_charm_haproxy_route_tcp_requirer_fixture(
             juju.remove_relation(f"{app_name}:{endpoint}", relation.related_app)
 
     juju.wait(
-        lambda status: (jubilant.all_agents_idle(status)),
+        lambda status: jubilant.all_agents_idle(status),
     )

--- a/haproxy-route-policy-operator/tests/integration/conftest.py
+++ b/haproxy-route-policy-operator/tests/integration/conftest.py
@@ -61,6 +61,7 @@ def application_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, charm:
         charm=charm,
         app=app_name,
         base="ubuntu@24.04",
+        log=False,
     )
     return app_name
 
@@ -94,6 +95,7 @@ def any_charm_haproxy_route_policy_requirer_fixture(
             ),
             "python-packages": "pydantic~=2.10\nvalidators",
         },
+        log=False,
     )
     juju.wait(
         lambda status: jubilant.all_active(
@@ -114,6 +116,7 @@ def postgresql_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju):
         app=POSTGRESQL_APPLICATION,
         channel="16/edge",
         base="ubuntu@24.04",
+        log=False,
     )
     juju.wait(
         lambda status: jubilant.all_active(status, POSTGRESQL_APPLICATION),

--- a/haproxy-route-policy-operator/tests/integration/test_charm.py
+++ b/haproxy-route-policy-operator/tests/integration/test_charm.py
@@ -21,7 +21,9 @@ def test_charm_becomes_active_after_relation_with_postgresql(
         The charm is blocked before relation and active after relating with PostgreSQL.
     """
     postgresql_app = "postgresql"
-    juju.deploy("postgresql", app=postgresql_app, channel="16/edge", base="ubuntu@24.04")
+    juju.deploy(
+        "postgresql", app=postgresql_app, channel="16/edge", base="ubuntu@24.04", log=False
+    )
 
     juju.wait(lambda status: jubilant.all_blocked(status, application))
 

--- a/haproxy-spoe-auth-operator/tests/integration/conftest.py
+++ b/haproxy-spoe-auth-operator/tests/integration/conftest.py
@@ -71,9 +71,10 @@ def application_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, charm:
         charm=charm,
         app=app_name,
         base="ubuntu@24.04",
+        log=False,
     )
     juju.wait(
-        lambda status: (jubilant.all_blocked(status, app_name)),
+        lambda status: jubilant.all_blocked(status, app_name),
         timeout=JUJU_WAIT_TIMEOUT,
     )
     return app_name

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -122,6 +122,7 @@ def application_fixture(pytestconfig: pytest.Config, lxd_juju: jubilant.Juju):
         charm=charm_file,
         app=app_name,
         base="ubuntu@24.04",
+        log=False,
     )
     return app_name
 
@@ -158,6 +159,7 @@ def haproxy_ddos_protection_configurator_fixture(
         charm=charm_file,
         app=ddos_app_name,
         base="ubuntu@24.04",
+        log=False,
     )
 
     return ddos_app_name
@@ -213,6 +215,7 @@ def certificate_provider_application_fixture(
         "self-signed-certificates",
         app=SELF_SIGNED_CERTIFICATES_APP_NAME,
         channel="1/edge",
+        log=False,
     )
     return SELF_SIGNED_CERTIFICATES_APP_NAME
 
@@ -225,15 +228,22 @@ def deploy_iam_bundle_fixture(k8s_juju: jubilant.Juju):
         logger.info("identity-platform is already deployed")
         return
     k8s_juju.deploy(
-        "self-signed-certificates", channel="1/stable", revision=317, trust=True
+        "self-signed-certificates",
+        channel="1/stable",
+        revision=317,
+        trust=True,
+        log=False,
     )
-    k8s_juju.deploy("hydra", channel="latest/edge", revision=399, trust=True)
-    k8s_juju.deploy("kratos", channel="latest/edge", revision=567, trust=True)
+    k8s_juju.deploy("hydra", channel="latest/edge", revision=399, trust=True, log=False)
+    k8s_juju.deploy(
+        "kratos", channel="latest/edge", revision=567, trust=True, log=False
+    )
     k8s_juju.deploy(
         "identity-platform-login-ui-operator",
         channel="latest/edge",
         revision=200,
         trust=True,
+        log=False,
     )
     k8s_juju.deploy(
         "traefik-k8s",
@@ -241,6 +251,7 @@ def deploy_iam_bundle_fixture(k8s_juju: jubilant.Juju):
         channel="latest/edge",
         revision=270,
         trust=True,
+        log=False,
     )
     k8s_juju.deploy(
         "postgresql-k8s",
@@ -252,6 +263,7 @@ def deploy_iam_bundle_fixture(k8s_juju: jubilant.Juju):
             "plugin_hstore_enable": "true",
             "plugin_pg_trgm_enable": "true",
         },
+        log=False,
     )
     # Integrations
     k8s_juju.integrate(
@@ -326,6 +338,7 @@ def deploy_any_charm_haproxy_route_requirer(
                 "src-overwrite": f"@{tf.name}",
                 "python-packages": "pydantic\ncryptography==45.0.6\nvalidators",
             },
+            log=False,
         )
     return app_name
 
@@ -382,6 +395,7 @@ def deploy_spoe_auth(
         charm=charm_file,
         app=app_name,
         config={"hostname": host_name},
+        log=False,
     )
     return app_name
 


### PR DESCRIPTION
Disable logging for jubilant `juju.deploy()`

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
