### PR TITLE
fix: add missing settings from haproxy-route-tcp relation template

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-04-17
+
+- Added missing settings from haproxy-route-tcp relation template.
+
 ## 2026-04-01
 
 - Fixed hosts validation in haproxy-route and haproxy-route-tcp relation libraries.

--- a/docs/release-notes/artifacts/pr0470.yaml
+++ b/docs/release-notes/artifacts/pr0470.yaml
@@ -1,0 +1,13 @@
+version_schema: 2
+changes:
+  - title: Added missing settings from haproxy-route-tcp relation template
+    author: skatsaounis
+    type: bugfix
+    description: >
+      Added missing settings to the haproxy-route-tcp relation template,
+      including backend timeouts.
+    urls:
+      pr:
+        - https://github.com/canonical/haproxy-operator/pull/470
+    visibility: public
+    highlight: false

--- a/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
@@ -70,6 +70,17 @@ backend {{ frontend.default_backend_name }}
     hash-type consistent
 {% endif %}
 {% endif %}
+{% if frontend.default_backend.application_data.timeout %}
+{% if frontend.default_backend.application_data.timeout.server %}
+    timeout server {{ frontend.default_backend.application_data.timeout.server }}s
+{% endif %}
+{% if frontend.default_backend.application_data.timeout.connect %}
+    timeout connect {{ frontend.default_backend.application_data.timeout.connect }}s
+{% endif %}
+{% if frontend.default_backend.application_data.timeout.queue %}
+    timeout queue {{ frontend.default_backend.application_data.timeout.queue }}s
+{% endif %}
+{% endif %}
 {% if frontend.default_backend.application_data.retry %}
     retries {{ frontend.default_backend.application_data.retry.count }}
 {% if frontend.default_backend.application_data.retry.redispatch %}
@@ -92,6 +103,17 @@ backend {{ backend.name }}
     balance {{ backend.application_data.load_balancing.algorithm.value }}
 {% if backend.application_data.load_balancing.consistent_hashing %}
     hash-type consistent
+{% endif %}
+{% if backend.application_data.timeout %}
+{% if backend.application_data.timeout.server %}
+    timeout server {{ backend.application_data.timeout.server }}s
+{% endif %}
+{% if backend.application_data.timeout.connect %}
+    timeout connect {{ backend.application_data.timeout.connect }}s
+{% endif %}
+{% if backend.application_data.timeout.queue %}
+    timeout queue {{ backend.application_data.timeout.queue }}s
+{% endif %}
 {% endif %}
 {% endif %}
 {% if backend.application_data.retry %}

--- a/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
@@ -104,6 +104,7 @@ backend {{ backend.name }}
 {% if backend.application_data.load_balancing.consistent_hashing %}
     hash-type consistent
 {% endif %}
+{% endif %}
 {% if backend.application_data.timeout %}
 {% if backend.application_data.timeout.server %}
     timeout server {{ backend.application_data.timeout.server }}s
@@ -113,7 +114,6 @@ backend {{ backend.name }}
 {% endif %}
 {% if backend.application_data.timeout.queue %}
     timeout queue {{ backend.application_data.timeout.queue }}s
-{% endif %}
 {% endif %}
 {% endif %}
 {% if backend.application_data.retry %}

--- a/haproxy-operator/tests/integration/haproxy_route_tcp_requirer.py
+++ b/haproxy-operator/tests/integration/haproxy_route_tcp_requirer.py
@@ -111,3 +111,20 @@ class AnyCharm(AnyCharmBase):
             retry_count=3,
             retry_redispatch=True,
         )
+
+    def update_relation_with_timeouts(self):
+        """Update haproxy-route-tcp relation data with timeouts"""
+        self._haproxy_route_tcp.provide_haproxy_route_tcp_requirements(
+            port=4444,
+            backend_port=4000,
+            sni=CNAME,
+            check_type=TCPHealthCheckType.GENERIC,
+            check_interval=60,
+            check_rise=3,
+            check_fall=3,
+            check_send="ping\r\n",
+            check_expect="pong",
+            server_timeout=10,
+            connect_timeout=5,
+            queue_timeout=2,
+        )

--- a/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
+++ b/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
@@ -73,3 +73,27 @@ def test_haproxy_route_tcp(
             "hash-type consistent",
         ]
     )
+
+    # Test with timeouts
+    juju.run(
+        f"{any_charm_haproxy_route_tcp_requirer}/0",
+        "rpc",
+        {"method": "update_relation_with_timeouts"},
+    )
+    juju.wait(
+        lambda status: jubilant.all_active(
+            status, configured_application_with_tls, any_charm_haproxy_route_tcp_requirer
+        )
+    )
+
+    haproxy_config = juju.ssh(
+        f"{configured_application_with_tls}/0", "cat /etc/haproxy/haproxy.cfg"
+    )
+    assert all(
+        entry in haproxy_config
+        for entry in [
+            "timeout server 10s",
+            "timeout connect 5s",
+            "timeout queue 2s",
+        ]
+    )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

The `haproxy-route-tcp` relation supports setting `server_timeout`, `connect_timeout`, and `queue_timeout` in the HaproxyRouteTcpRequirer and is adding them to the relation databag with _generate_application_data. This PR is extending the `haproxy_route_tcp.cfg.j2` Jinja template to use them.

### Rationale

<!-- The reason the change is needed -->

The current template is not respecting the values set to the application databag.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

N/A

### Library Changes

<!-- Any changes to charm libraries -->

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] A [change artifact](https://github.com/canonical/haproxy-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) was added for user-relevant changes in `docs/release-notes/artifacts`. If this PR does not require a change artifact, the PR has been tagged with `no-release-note`. 
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
