### PR TITLE
docs: add relation endpoints reference page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-05-28
+
+- Added relation endpoints reference page.
+
 ## 2026-04-17
 
 - Added missing settings from haproxy-route-tcp relation template.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,6 +14,7 @@ The pages in this section contain technical information for topics relevant to t
 :maxdepth: 1
 grpc-support.md
 http2-support.md
+relation-endpoints.md
 spoe-auth-support.md
 Changelog <../changelog.md>
 ```

--- a/docs/reference/relation-endpoints.md
+++ b/docs/reference/relation-endpoints.md
@@ -1,0 +1,219 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Reference documentation for all relation endpoints supported by the HAProxy charm."
+---
+
+(reference_relation_endpoints)=
+
+# Relation endpoints
+
+This page lists all relation endpoints exposed by the HAProxy charm, grouped by role.
+
+## Provides
+
+### `haproxy-route`
+
+- **Interface**: `haproxy-route`
+- **Supported charms**: Any charm implementing the `haproxy-route` interface
+
+Allows HTTP-based backend charms to register themselves with HAProxy, configuring hosts, paths, ports, load-balancing, health checks, and rewrite rules.
+
+Example `haproxy-route` integrate command:
+
+```shell
+juju integrate <charm>:haproxy-route haproxy:haproxy-route
+```
+
+---
+
+### `haproxy-route-tcp`
+
+- **Interface**: `haproxy-route-tcp`
+- **Supported charms**: Any charm implementing the `haproxy-route-tcp` interface
+
+Allows TCP-based backend charms to register themselves with HAProxy using SNI-based routing, with support for TLS termination and health checks.
+
+Example `haproxy-route-tcp` integrate command:
+
+```shell
+juju integrate <charm>:haproxy-route-tcp haproxy:haproxy-route-tcp
+```
+
+---
+
+### `ingress`
+
+- **Interface**: `ingress`
+- **Supported charms**: Any charm implementing the traefik-compatible `ingress` interface
+
+Exposes per-application ingress to charms that use the traefik-compatible `ingress` interface, load-balancing traffic across all units of the application.
+
+Example `ingress` integrate command:
+
+```shell
+juju integrate <charm>:ingress haproxy:ingress
+```
+
+---
+
+### `ingress-per-unit`
+
+- **Interface**: `ingress_per_unit`
+- **Supported charms**: Any charm implementing the traefik-compatible `ingress-per-unit` interface
+
+Provides a dedicated ingress URL per unit, rather than per application, for charms that use the traefik-compatible `ingress-per-unit` interface.
+
+Example `ingress-per-unit` integrate command:
+
+```shell
+juju integrate <charm>:ingress-per-unit haproxy:ingress-per-unit
+```
+
+---
+
+### `website`
+
+- **Interface**: `http`
+- **Supported charms**: Any charm implementing the `http` interface
+
+Legacy interface that exposes HAProxy as an HTTP endpoint to other charms expecting a reverse proxy. Prefer `haproxy-route` for new integrations.
+
+Example `website` integrate command:
+
+```shell
+juju integrate <charm>:reverseproxy haproxy:website
+```
+
+---
+
+### `cos-agent`
+
+- **Interface**: `cos_agent`
+- **Supported charms**: [grafana-agent](https://charmhub.io/grafana-agent)
+
+Integrates HAProxy with the Canonical Observability Stack, enabling metrics and log collection via the Grafana Agent.
+
+Example `cos-agent` integrate command:
+
+```shell
+juju integrate grafana-agent:juju-info haproxy:cos-agent
+```
+
+---
+
+## Requires
+
+### `certificates`
+
+- **Interface**: `tls-certificates`
+- **Supported charms**: [self-signed-certificates](https://charmhub.io/self-signed-certificates), [manual-tls-certificates](https://charmhub.io/manual-tls-certificates)
+
+Requests TLS certificates from a certificate authority charm so HAProxy can serve HTTPS frontends.
+
+Example `certificates` integrate command:
+
+```shell
+juju integrate haproxy:certificates self-signed-certificates:certificates
+```
+
+---
+
+### `reverseproxy`
+
+- **Interface**: `http`
+- **Supported charms**: Any charm implementing the `http` interface
+
+Legacy interface allowing backend charms to register themselves as reverse proxy targets. Prefer `haproxy-route` for new integrations.
+
+Example `reverseproxy` integrate command:
+
+```shell
+juju integrate haproxy:reverseproxy <charm>:website
+```
+
+---
+
+### `ha`
+
+- **Interface**: `hacluster`
+- **Supported charms**: [hacluster](https://charmhub.io/hacluster)
+
+Integrates with the `hacluster` charm to enable active/passive high-availability using a shared virtual IP address.
+
+Example `ha` integrate command:
+
+```shell
+juju integrate haproxy:ha hacluster:ha
+```
+
+---
+
+### `receive-ca-certs`
+
+- **Interface**: `certificate_transfer`
+- **Supported charms**: Any charm implementing the `certificate_transfer` interface
+
+Receives CA certificates from another charm so HAProxy can trust custom certificate authorities when connecting to backends.
+
+Example `receive-ca-certs` integrate command:
+
+```shell
+juju integrate haproxy:receive-ca-certs <charm>:send-ca-cert
+```
+
+---
+
+### `spoe-auth`
+
+- **Interface**: `spoe-auth`
+- **Supported charms**: [haproxy-spoe-auth](https://charmhub.io/haproxy-spoe-auth)
+
+Delegates request authentication to an external SPOE agent using OpenID Connect. See {ref}`reference_spoe-auth_support` for details.
+
+Example `spoe-auth` integrate command:
+
+```shell
+juju integrate haproxy:spoe-auth haproxy-spoe-auth:spoe-auth
+```
+
+---
+
+### `ddos-protection`
+
+- **Interface**: `ddos_protection`
+- **Supported charms**: [haproxy-ddos-protection-configurator](https://charmhub.io/haproxy-ddos-protection-configurator)
+
+Receives DDoS protection policy settings — including rate limits, connection limits, and timeouts — from an external configurator charm.
+
+Example `ddos-protection` integrate command:
+
+```shell
+juju integrate haproxy:ddos-protection haproxy-ddos-protection-configurator:ddos-protection
+```
+
+---
+
+### `haproxy-route-policy`
+
+- **Interface**: `haproxy-route-policy`
+- **Supported charms**: [haproxy-route-policy](https://charmhub.io/haproxy-route-policy)
+
+Receives approved routing policy rules from an external policy operator, controlling which backend route requests are permitted.
+
+Example `haproxy-route-policy` integrate command:
+
+```shell
+juju integrate haproxy:haproxy-route-policy haproxy-route-policy:haproxy-route-policy
+```
+
+---
+
+## Peers
+
+### `haproxy-peers`
+
+- **Interface**: `haproxy-peers`
+- **Supported charms**: Internal peer relation, no external charms
+
+Used by HAProxy units to coordinate state with each other, required for correct behaviour when multiple units are deployed.

--- a/docs/reference/relation-endpoints.md
+++ b/docs/reference/relation-endpoints.md
@@ -45,9 +45,9 @@ juju integrate <charm>:haproxy-route-tcp haproxy:haproxy-route-tcp
 ### `ingress`
 
 - **Interface**: `ingress`
-- **Supported charms**: Any charm implementing the traefik-compatible `ingress` interface
+- **Supported charms**: Any charm implementing the Traefik-compatible `ingress` interface
 
-Exposes per-application ingress to charms that use the traefik-compatible `ingress` interface, load-balancing traffic across all units of the application.
+Exposes per-application ingress to charms that use the Traefik-compatible `ingress` interface, load-balancing traffic across all units of the application.
 
 Example `ingress` integrate command:
 
@@ -60,9 +60,9 @@ juju integrate <charm>:ingress haproxy:ingress
 ### `ingress-per-unit`
 
 - **Interface**: `ingress_per_unit`
-- **Supported charms**: Any charm implementing the traefik-compatible `ingress-per-unit` interface
+- **Supported charms**: Any charm implementing the Traefik-compatible `ingress-per-unit` interface
 
-Provides a dedicated ingress URL per unit, rather than per application, for charms that use the traefik-compatible `ingress-per-unit` interface.
+Provides a dedicated ingress URL per unit, rather than per application, for charms that use the Traefik-compatible `ingress-per-unit` interface.
 
 Example `ingress-per-unit` integrate command:
 
@@ -140,6 +140,7 @@ juju integrate haproxy:reverseproxy <charm>:website
 - **Supported charms**: [hacluster](https://charmhub.io/hacluster)
 
 Integrates with the `hacluster` charm to enable active/passive high-availability using a shared virtual IP address.
+See {ref}`how_to_configure_high_availability` for more details.
 
 Example `ha` integrate command:
 
@@ -185,6 +186,7 @@ juju integrate haproxy:spoe-auth haproxy-spoe-auth:spoe-auth
 - **Supported charms**: [haproxy-ddos-protection-configurator](https://charmhub.io/haproxy-ddos-protection-configurator)
 
 Receives DDoS protection policy settings — including rate limits, connection limits, and timeouts — from an external configurator charm.
+See {ref}`how_to_enable_ddos_protection` for more details.
 
 Example `ddos-protection` integrate command:
 
@@ -216,4 +218,4 @@ juju integrate haproxy:haproxy-route-policy haproxy-route-policy:haproxy-route-p
 - **Interface**: `haproxy-peers`
 - **Supported charms**: Internal peer relation, no external charms
 
-Used by HAProxy units to coordinate state with each other, required for correct behaviour when multiple units are deployed.
+Used by HAProxy units to coordinate state with each other, required for correct behavior when multiple units are deployed.


### PR DESCRIPTION
#### What this PR does

Adds a new reference page `docs/reference/relation-endpoints.md` documenting all 14 relation endpoints of the HAProxy charm (6 provides, 7 requires, 1 peer), following the Canonical charm template structure.

#### Why we need it

The MAAS team requested relation documentation for the HAProxy charm in order to ship the charm alongside a customer solution.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors