### PR TITLE
fix: enforce positive timeout values in haproxy-route(-tcp)

### DIFF
--- a/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -186,7 +186,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
@@ -575,12 +575,15 @@ class TimeoutConfiguration(BaseModel):
 
     server: Optional[int] = Field(
         description="Timeout (in seconds) for requests from haproxy to backend servers.",
+        gt=0,
     )
     connect: Optional[int] = Field(
         description="Timeout (in seconds) for client requests to haproxy.",
+        gt=0,
     )
     queue: Optional[int] = Field(
         description="Timeout (in seconds) for requests in the queue.",
+        gt=0,
     )
 
 

--- a/haproxy-operator/lib/charms/haproxy/v2/haproxy_route.py
+++ b/haproxy-operator/lib/charms/haproxy/v2/haproxy_route.py
@@ -154,7 +154,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
@@ -505,13 +505,17 @@ class TimeoutConfiguration(BaseModel):
     server: int = Field(
         description="Timeout (in seconds) for requests from haproxy to backend servers.",
         default=60,
+        gt=0,
     )
     connect: int = Field(
-        description="Timeout (in seconds) for client requests to haproxy.", default=60
+        description="Timeout (in seconds) for client requests to haproxy.",
+        default=60,
+        gt=0,
     )
     queue: int = Field(
         description="Timeout (in seconds) for requests in the queue.",
         default=60,
+        gt=0,
     )
 
 


### PR DESCRIPTION
#### What this PR does
Add constrains in the haproxy-route and haproxy-route-tcp lib for the timeout values to ensure that they are positive

#### Why we need it

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [ ] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

