### PR TITLE
Mark secondary endpoints as optional

### DIFF
--- a/haproxy-operator/charmcraft.yaml
+++ b/haproxy-operator/charmcraft.yaml
@@ -54,15 +54,19 @@ requires:
     interface: hacluster
   receive-ca-certs:
     interface: certificate_transfer
+    optional: true
     description: Receive a CA certs for haproxy to trust.
   spoe-auth:
     interface: spoe-auth
+    optional: true
     description: Relation to provide authentication proxy to HAProxy.
   ddos-protection:
     interface: ddos_protection
+    optional: true
     limit: 1
   haproxy-route-policy:
     interface: haproxy-route-policy
+    optional: true
     limit: 1
 
 
@@ -73,8 +77,10 @@ provides:
     interface: ingress_per_unit
   cos-agent:
     interface: cos_agent
+    optional: true
   website:
     interface: http
+    optional: true
   haproxy-route:
     interface: haproxy-route
   haproxy-route-tcp:


### PR DESCRIPTION
Marks the following endpoints as `optional: true` in `charmcraft.yaml`:

- `receive-ca-certs`, `spoe-auth`, `ddos-protection`, `haproxy-route-policy` (requires) - additive features; charm reaches active without them
- `cos-agent`, `website` (provides) - secondary/additive; not part of proxy mode selection