### PR TITLE
feat: add port-range attribute to haproxy-route-tcp

### DIFF
--- a/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -157,6 +157,7 @@ class SomeCharm(CharmBase):
 
 import json
 import logging
+import re
 from collections import defaultdict
 from enum import Enum
 from typing import Annotated, Any, MutableMapping, Optional, cast
@@ -186,11 +187,48 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
 HAPROXY_CONFIG_INVALID_CHARACTERS = "\n\t#\\'\"\r$ "
+_PORT_RANGE_RE = re.compile(r"^(\d+)-(\d+)$")
+
+
+def _parse_port_range(port_range: str) -> tuple[int, int]:
+    """Parse and validate a port range string into a (start, end) tuple.
+
+    Args:
+        port_range: String in the format "START-END".
+
+    Raises:
+        ValueError: When the format is invalid or the range is out of bounds.
+
+    Returns:
+        tuple[int, int]: (start, end) both inclusive.
+    """
+    match = _PORT_RANGE_RE.match(port_range)
+    if not match:
+        raise ValueError(f"port_range must be in 'START-END' format, got: {port_range!r}")
+    start, end = int(match.group(1)), int(match.group(2))
+    if not (1 <= start < end <= 65535):
+        raise ValueError(
+            f"port_range bounds must satisfy 1 <= start < end <= 65535, got: {port_range!r}"
+        )
+    return start, end
+
+
+def expand_port_range(port_range: str) -> set[int]:
+    """Return the full set of ports covered by a range string.
+
+    Args:
+        port_range: A validated range string like "10500-10600".
+
+    Returns:
+        set[int]: Every port in [start, end] inclusive.
+    """
+    start, end = _parse_port_range(port_range)
+    return set(range(start, end + 1))
 
 
 def value_contains_invalid_characters(value: Optional[str]) -> Optional[str]:
@@ -592,8 +630,12 @@ class TcpRequirerApplicationData(_DatabagModel):
 
     Attributes:
         port: The port exposed on the provider.
+        port_range: A range of ports to expose, in 'START-END' format (e.g. '10500-10600').
+            Each port in the range is mapped 1:1 to the same port on the backend.
+            Mutually exclusive with per-port features like sni. At least one of
+            port or port_range must be provided.
         backend_port: The port where the backend service is listening. Defaults to the
-            provider port.
+            provider port. Only used when port (not port_range) is set.
         hosts: List of backend server addresses. Currently only support IP addresses.
         sni: Server name identification. Used to route traffic to the service.
         check: TCP health check configuration
@@ -609,7 +651,17 @@ class TcpRequirerApplicationData(_DatabagModel):
         proxy_protocol: Whether to enable PROXY protocol when connecting to backend servers.
     """
 
-    port: int = Field(description="The port exposed on the provider.", gt=0, le=65535)
+    port: Optional[int] = Field(
+        description="The port exposed on the provider.", default=None, gt=0, le=65535
+    )
+    port_range: Optional[str] = Field(
+        description=(
+            "A range of ports to expose on the provider, in 'START-END' format "
+            "(e.g. '10500-10600'). Each port is mapped 1:1 to the same port on the backend. "
+            "Cannot be combined with sni. At least one of port or port_range must be set."
+        ),
+        default=None,
+    )
     backend_port: Optional[int] = Field(
         description=(
             "The port where the backend service is listening. Defaults to the provider port."
@@ -663,15 +715,81 @@ class TcpRequirerApplicationData(_DatabagModel):
     )
 
     @model_validator(mode="after")
-    def assign_default_backend_port(self) -> "Self":
-        """Assign a default value to backend_port if not set.
+    def require_port_or_port_range(self) -> "Self":
+        """Require at least one of port or port_range to be set.
 
-        The value is equal to the provider port.
+        Raises:
+            ValueError: If neither port nor port_range is provided.
+
+        Returns:
+            The validated model.
+        """
+        if self.port is None and self.port_range is None:
+            raise ValueError("At least one of 'port' or 'port_range' must be set.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_port_range_format(self) -> "Self":
+        """Validate port_range format and bounds.
+
+        Raises:
+            ValueError: If port_range is set but has an invalid format or bounds.
+
+        Returns:
+            The validated model.
+        """
+        if self.port_range is not None:
+            _parse_port_range(self.port_range)
+        return self
+
+    @model_validator(mode="after")
+    def sni_forbidden_with_port_range(self) -> "Self":
+        """Forbid SNI when port_range is set.
+
+        Raises:
+            ValueError: If both port_range and sni are set.
+
+        Returns:
+            The validated model.
+        """
+        if self.port_range is not None and self.sni is not None:
+            raise ValueError("'sni' cannot be used together with 'port_range'.")
+        return self
+
+    @model_validator(mode="after")
+    def check_port_range_self_overlap(self) -> "Self":
+        """Validate that port and backend_port do not fall inside the port_range.
+
+        Raises:
+            ValueError: When port or backend_port overlaps with port_range.
+
+        Returns:
+            The validated model.
+        """
+        if self.port_range is None:
+            return self
+        range_ports = expand_port_range(self.port_range)
+        if self.port is not None and self.port in range_ports:
+            raise ValueError(
+                f"'port' ({self.port}) must not fall inside 'port_range' ({self.port_range})."
+            )
+        if self.backend_port is not None and self.backend_port in range_ports:
+            raise ValueError(
+                f"'backend_port' ({self.backend_port}) must not fall inside "
+                f"'port_range' ({self.port_range})."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def assign_default_backend_port(self) -> "Self":
+        """Assign a default value to backend_port if not set (single-port mode only).
+
+        The value is equal to the provider port. Only applied when port_range is not set.
 
         Returns:
             The model with backend_port default value applied.
         """
-        if self.backend_port is None:
+        if self.port_range is None and self.backend_port is None and self.port is not None:
             self.backend_port = self.port
         return self
 
@@ -741,20 +859,24 @@ class HaproxyRouteTcpRequirersData:
 
     @model_validator(mode="after")
     def check_ports_unique(self) -> Self:
-        """Check that requirers define unique ports.
+        """Check that requirers define unique ports across single ports and port ranges.
+
+        Each requirer contributes: its single 'port' (if set) plus all ports in 'port_range'
+        (if set). Any port claimed by more than one relation marks all involved relations invalid.
 
         Returns:
             The validated model, with invalid relation IDs updated in
                 `self.relation_ids_with_invalid_data`
         """
-        # Maybe the logic here can be optimized, we want to keep track of
-        # the relation IDs that request overlapping ports to ignore them during
-        # rendering of the haproxy configuration.
         relation_ids_per_port: dict[int, list[int]] = defaultdict(list[int])
         for requirer_data in self.requirers_data:
-            relation_ids_per_port[requirer_data.application_data.port].append(
-                requirer_data.relation_id
-            )
+            if requirer_data.application_data.port is not None:
+                relation_ids_per_port[requirer_data.application_data.port].append(
+                    requirer_data.relation_id
+                )
+            if requirer_data.application_data.port_range is not None:
+                for p in expand_port_range(requirer_data.application_data.port_range):
+                    relation_ids_per_port[p].append(requirer_data.relation_id)
 
         for relation_ids in relation_ids_per_port.values():
             if len(relation_ids) > 1:
@@ -983,6 +1105,7 @@ class HaproxyRouteTcpRequirer(Object):
         relation_name: str,
         *,
         port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1017,6 +1140,7 @@ class HaproxyRouteTcpRequirer(Object):
             charm: The charm that is instantiating the library.
             relation_name: The name of the relation to bind to.
             port: The provider port.
+            port_range: A range of ports to expose, in 'START-END' format.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1059,6 +1183,7 @@ class HaproxyRouteTcpRequirer(Object):
         # build the full application data
         self._application_data = self._generate_application_data(
             port=port,
+            port_range=port_range,
             backend_port=backend_port,
             hosts=hosts,
             sni=sni,
@@ -1111,7 +1236,8 @@ class HaproxyRouteTcpRequirer(Object):
     def provide_haproxy_route_tcp_requirements(
         self,
         *,
-        port: int,
+        port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1144,6 +1270,7 @@ class HaproxyRouteTcpRequirer(Object):
 
         Args:
             port: The provider port.
+            port_range: A range of ports to expose, in 'START-END' format.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1179,6 +1306,7 @@ class HaproxyRouteTcpRequirer(Object):
         self._unit_address = unit_address
         self._application_data = self._generate_application_data(
             port=port,
+            port_range=port_range,
             backend_port=backend_port,
             hosts=hosts,
             sni=sni,
@@ -1213,6 +1341,7 @@ class HaproxyRouteTcpRequirer(Object):
         self,
         *,
         port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1244,6 +1373,7 @@ class HaproxyRouteTcpRequirer(Object):
 
         Args:
             port: The provider port.
+            port_range: A range of ports to expose, in 'START-END' format.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1286,6 +1416,7 @@ class HaproxyRouteTcpRequirer(Object):
 
         application_data: dict[str, Any] = {
             "port": port,
+            "port_range": port_range,
             "backend_port": backend_port,
             "hosts": hosts,
             "sni": sni,
@@ -1452,8 +1583,8 @@ class HaproxyRouteTcpRequirer(Object):
 
     def update_relation_data(self) -> None:
         """Update both application and unit data in the relation."""
-        if not self._application_data.get("port"):
-            logger.warning("port must be set, skipping update.")
+        if not self._application_data.get("port") and not self._application_data.get("port_range"):
+            logger.warning("port or port_range must be set, skipping update.")
             return
 
         if relation := self.relation:
@@ -1561,6 +1692,18 @@ class HaproxyRouteTcpRequirer(Object):
             Self: The HaproxyRouteTcpRequirer class
         """
         self._application_data["port"] = port
+        return self
+
+    def configure_port_range(self, port_range: str) -> "Self":
+        """Set the provider port range for 1:1 TCP passthrough.
+
+        Args:
+            port_range: The port range in 'START-END' format (e.g. '10500-10600').
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["port_range"] = port_range
         return self
 
     def configure_backend_port(self, backend_port: int) -> "Self":

--- a/haproxy-operator/src/charm.py
+++ b/haproxy-operator/src/charm.py
@@ -418,8 +418,9 @@ class HAProxyCharm(ops.CharmBase):
             80,
             443,
             *(
-                frontend.port
+                p
                 for frontend in haproxy_route_requirers_information.valid_tcp_frontends()
+                for p in frontend.all_frontend_ports
             ),
             *(
                 backend.application_data.external_grpc_port
@@ -714,19 +715,22 @@ class HAProxyCharm(ops.CharmBase):
                         "The haproxy-route-tcp relation does not exist for this backend, skipping."
                     )
                     continue
+                port_repr = (
+                    frontend.port_range if frontend.port_range is not None else str(frontend.port)
+                )
                 if frontend.is_sni_routing_enabled:
                     self.haproxy_route_tcp_provider.publish_proxied_endpoints(
-                        [f"{backend.application_data.sni}:{frontend.port}"], relation
+                        [f"{backend.application_data.sni}:{port_repr}"], relation
                     )
                     continue
                 if ha_information.ha_integration_ready:
                     self.haproxy_route_tcp_provider.publish_proxied_endpoints(
-                        [f"{ha_information.vip}:{frontend.port}"], relation
+                        [f"{ha_information.vip}:{port_repr}"], relation
                     )
                     continue
                 self.haproxy_route_tcp_provider.publish_proxied_endpoints(
                     [
-                        f"{unit_address}:{frontend.port}"
+                        f"{unit_address}:{port_repr}"
                         for unit_address in self._get_peer_units_address()
                     ],
                     relation,

--- a/haproxy-operator/src/state/haproxy_route.py
+++ b/haproxy-operator/src/state/haproxy_route.py
@@ -631,7 +631,11 @@ class HaproxyRouteRequirersInformation:
             for backend in valid_backends
             if backend.application_data.external_grpc_port
         }
-        tcp_ports = {frontend.port: frontend for frontend in self.tcp_frontends}
+        # Build a mapping from individual port -> frontend, expanding ranges.
+        tcp_ports: dict[int, HAProxyRouteTcpFrontend] = {}
+        for frontend in self.tcp_frontends:
+            for p in frontend.all_frontend_ports:
+                tcp_ports[p] = frontend
 
         # Check for conflicts between standard HTTP and TCP/gRPC ports
         if has_http_backends:
@@ -686,7 +690,7 @@ class HaproxyRouteRequirersInformation:
         return [
             frontend
             for frontend in self.tcp_frontends
-            if frontend.port not in self.ports_with_conflicts
+            if not any(p in self.ports_with_conflicts for p in frontend.all_frontend_ports)
         ]
 
     @property
@@ -787,14 +791,24 @@ def parse_haproxy_route_tcp_requirers_data(
 ) -> list[HAProxyRouteTcpFrontend]:
     """Parse HAProxyRouteTcpFrontend data from requirers into frontend objects.
 
+    Single-port requirers are grouped by port (enabling SNI-based multi-backend merging).
+    Port-range requirers each become a standalone frontend (no merging, plain TCP passthrough).
+
     Returns:
         list[HAProxyRouteTcpFrontend]: The parsed frontend data.
     """
     port_to_backends_mapping: dict[int, list[HAProxyRouteTcpBackend]] = defaultdict(list)
+    range_backends: list[HAProxyRouteTcpBackend] = []
+
     for requirer in tcp_requirers.requirers_data:
         endpoint = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(requirer)
-        port_to_backends_mapping[endpoint.application_data.port].append(endpoint)
+        if requirer.application_data.port_range is not None:
+            range_backends.append(endpoint)
+        else:
+            port_to_backends_mapping[endpoint.application_data.port].append(endpoint)
+
     tcp_frontends: list[HAProxyRouteTcpFrontend] = []
+
     for backends in port_to_backends_mapping.values():
         try:
             frontend = HAProxyRouteTcpFrontend.from_backends(backends)
@@ -802,6 +816,15 @@ def parse_haproxy_route_tcp_requirers_data(
         except HAProxyRouteTcpFrontendValidationError as exc:
             logger.error(f"Failed to parse TCP frontend: {exc}")
             continue
+
+    for backend in range_backends:
+        try:
+            frontend = HAProxyRouteTcpFrontend.from_backends([backend])
+            tcp_frontends.append(frontend)
+        except HAProxyRouteTcpFrontendValidationError as exc:
+            logger.error(f"Failed to parse TCP range frontend: {exc}")
+            continue
+
     return tcp_frontends
 
 

--- a/haproxy-operator/src/state/haproxy_route_tcp.py
+++ b/haproxy-operator/src/state/haproxy_route_tcp.py
@@ -10,6 +10,7 @@ from charms.haproxy.v1.haproxy_route_tcp import (
     HaproxyRouteTcpRequirerData,
     TCPHealthCheckType,
     TCPServerHealthCheck,
+    expand_port_range,
 )
 from pydantic import Field, IPvAnyAddress
 from pydantic.dataclasses import dataclass
@@ -41,6 +42,7 @@ class HaproxyRouteTcpServer:
         server_name: The name of the unit with invalid characters replaced.
         address: The IP address of the requirer unit.
         port: The port that the requirer application wishes to be exposed.
+            None means portless (used with port_range for 1:1 passthrough via set-dst-port).
         check: Health check configuration.
         maxconn: Maximum allowed connections before requests are queued.
         send_proxy: Whether to enable PROXY protocol for this server.
@@ -48,7 +50,7 @@ class HaproxyRouteTcpServer:
 
     server_name: str
     address: IPvAnyAddress
-    port: int
+    port: Optional[int]
     check: Optional[TCPServerHealthCheck]
     maxconn: Optional[int]
     send_proxy: bool = False
@@ -103,6 +105,9 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
         sequential server names and using the application's backend port and
         health check configuration.
 
+        When port_range is set, servers are rendered without a port (port=None) so
+        HAProxy uses the captured destination port for 1:1 passthrough.
+
         Returns:
             list[HaproxyRouteTcpServer]: List of configured backend servers.
         """
@@ -111,13 +116,14 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
         if not backend_addresses:
             backend_addresses = [unit_data.address for unit_data in self.units_data]
 
+        is_port_range = self.application_data.port_range is not None
         for i, address in enumerate(backend_addresses):
             servers.append(
                 HaproxyRouteTcpServer(
                     server_name=f"{self.application}-{i}",
-                    port=cast(int, self.application_data.backend_port),
+                    port=None if is_port_range else cast(int, self.application_data.backend_port),
                     address=address,
-                    check=self.application_data.check,
+                    check=None if is_port_range else self.application_data.check,
                     maxconn=self.application_data.server_maxconn,
                     send_proxy=self.application_data.proxy_protocol,
                 )
@@ -128,12 +134,15 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
     def name(self) -> str:
         """Get the unique name for this TCP endpoint.
 
-        Combines the application name and frontend port to create a unique
+        Combines the application name and frontend port (or port range) to create a unique
         identifier for the HAProxy configuration section.
 
         Returns:
-            str: The endpoint name in format "{application}_{port}".
+            str: The endpoint name in format "{application}_{port}" or
+                "{application}_{start}_{end}".
         """
+        if self.application_data.port_range is not None:
+            return f"{self.application}_{self.application_data.port_range.replace('-', '_')}"
         return f"{self.application}_{self.application_data.port}"
 
     @property
@@ -194,14 +203,20 @@ class HAProxyRouteTcpFrontend:
     """A representation of a TCP frontend in the haproxy config.
 
     Attrs:
-        port: The port exposed on the provider.
         backends: List of backend endpoints for this frontend.
+        port: The port exposed on the provider (single-port mode).
+        port_range: The port range in 'START-END' format (range mode).
         enforce_tls: Whether to enforce TLS for all traffic.
         tls_terminate: Whether to enable TLS termination.
     """
 
-    port: int = Field(description="The port exposed on the provider.", gt=0, le=65535)
     backends: list[HAProxyRouteTcpBackend] = Field(description="List of backend endpoints.")
+    port: Optional[int] = Field(
+        description="The port exposed on the provider.", default=None, gt=0, le=65535
+    )
+    port_range: Optional[str] = Field(
+        description="The port range in 'START-END' format.", default=None
+    )
     enforce_tls: bool = Field(description="Whether to enforce TLS for all traffic.", default=True)
     tls_terminate: bool = Field(description="Whether to enable tls termination.", default=True)
     relation_ids_with_invalid_data: set[int] = Field(
@@ -225,6 +240,7 @@ class HAProxyRouteTcpFrontend:
         if len(backends) == 1:
             return cls(
                 port=backends[0].application_data.port,
+                port_range=backends[0].application_data.port_range,
                 backends=backends,
                 enforce_tls=backends[0].application_data.enforce_tls,
                 tls_terminate=backends[0].application_data.tls_terminate,
@@ -263,11 +279,46 @@ class HAProxyRouteTcpFrontend:
             )
         return cls(
             port=rendered_backends[0].application_data.port,
+            port_range=None,
             backends=rendered_backends,
             enforce_tls=rendered_backends[0].application_data.enforce_tls,
             tls_terminate=rendered_backends[0].application_data.tls_terminate,
             relation_ids_with_invalid_data=relation_ids_with_invalid_data,
         )
+
+    @property
+    def frontend_name(self) -> str:
+        """Get the unique frontend name for this TCP frontend.
+
+        Returns:
+            str: The frontend name.
+        """
+        if self.port_range is not None:
+            return f"haproxy_route_tcp_{self.port_range.replace('-', '_')}"
+        return f"haproxy_route_tcp_{self.port}"
+
+    @property
+    def bind_address(self) -> str:
+        """Get the bind address string for the HAProxy frontend bind directive.
+
+        Returns:
+            str: Either a single port number or a 'START-END' range string.
+        """
+        return self.port_range if self.port_range is not None else str(self.port)
+
+    @property
+    def all_frontend_ports(self) -> list[int]:
+        """Get every individual port this frontend binds.
+
+        Used for open_ports() registration and conflict detection.
+
+        Returns:
+            list[int]: Single-element list for single-port frontends,
+                or the full expanded range for port_range frontends.
+        """
+        if self.port_range is not None:
+            return sorted(expand_port_range(self.port_range))
+        return [self.port]  # type: ignore[list-item]
 
     @property
     def backend_sni_routing_configurations(self) -> list[BackendRoutingConfiguration]:
@@ -315,7 +366,7 @@ class HAProxyRouteTcpFrontend:
         Returns:
             str: The name of the default backend.
         """
-        return f"haproxy_route_tcp_{self.port}_default_backend"
+        return f"{self.frontend_name}_default_backend"
 
     @property
     def content_inspect_delay_required(self) -> bool:

--- a/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
@@ -1,7 +1,7 @@
 {% macro render_tcp_server(server) -%}
     server
 {{ server.server_name }}
-{{ server.address }}:{{ server.port }}
+{{ server.address }}{% if server.port %}:{{ server.port }}{% endif %}
 {% if server.check %}
 check
 inter {{ server.check.interval }}s
@@ -17,10 +17,10 @@ send-proxy
 {%- endmacro %}
 
 {% for frontend in tcp_frontends %}
-frontend haproxy_route_tcp_{{ frontend.port }}
+frontend {{ frontend.frontend_name }}
     mode tcp
     option tcplog
-    bind [::]:{{ frontend.port }} v4v6 {% if frontend.tls_terminate %} ssl crt {{ haproxy_crt_dir }} {% endif +%}
+    bind [::]:{{ frontend.bind_address }} v4v6 {% if not frontend.port_range and frontend.tls_terminate %} ssl crt {{ haproxy_crt_dir }} {% endif +%}
 
 {# DDOS protection configuration. #}
 {% if ddos_protection_config.client_timeout %}
@@ -40,8 +40,13 @@ frontend haproxy_route_tcp_{{ frontend.port }}
     http-request allow if allowed_ips
 {% endif %}
 
-{# This configuration block is only applicable when not terminating TLS. #}
-{% if not frontend.tls_terminate %}
+{# For port_range frontends: capture the incoming destination port for 1:1 passthrough. #}
+{% if frontend.port_range %}
+    tcp-request session set-dst-port fc_dst_port
+{% endif %}
+
+{# This configuration block is only applicable when not terminating TLS (and not a range frontend). #}
+{% if not frontend.port_range and not frontend.tls_terminate %}
 {% if frontend.content_inspect_delay_required %}
     tcp-request inspect-delay 5s
 {% endif %}

--- a/haproxy-operator/tests/integration/haproxy_route_tcp_requirer.py
+++ b/haproxy-operator/tests/integration/haproxy_route_tcp_requirer.py
@@ -137,3 +137,9 @@ class AnyCharm(AnyCharmBase):
             proxy_protocol=True,
             sni=CNAME,
         )
+
+    def update_relation_with_port_range(self):
+        """Update haproxy-route-tcp relation data with a port range (plain TCP passthrough)."""
+        self._haproxy_route_tcp.provide_haproxy_route_tcp_requirements(
+            port_range="10500-10510",
+        )

--- a/haproxy-operator/tests/unit/conftest.py
+++ b/haproxy-operator/tests/unit/conftest.py
@@ -461,8 +461,9 @@ def tcp_reconcile_context_fixture():
 
 def build_haproxy_route_tcp_relation(
     *,
-    port: int = 4000,
+    port: int | None = 4000,
     backend_port: int | None = None,
+    port_range: str | None = None,
     sni: str | None = None,
     enforce_tls: bool = True,
     tls_terminate: bool = False,
@@ -471,8 +472,9 @@ def build_haproxy_route_tcp_relation(
     """Build a scenario Relation for haproxy-route-tcp.
 
     Args:
-        port: Frontend port.
+        port: Frontend port (mutually exclusive with port_range).
         backend_port: Backend port (defaults to port).
+        port_range: Port range string (e.g. "10500-10510").
         sni: Server Name Indication value.
         enforce_tls: Whether to enforce TLS.
         tls_terminate: Whether to terminate TLS.
@@ -482,12 +484,15 @@ def build_haproxy_route_tcp_relation(
         A scenario Relation for haproxy-route-tcp.
     """
     app_data: dict[str, str | int | bool | None] = {
-        "port": port,
         "enforce_tls": enforce_tls,
         "tls_terminate": tls_terminate,
     }
+    if port is not None:
+        app_data["port"] = port
     if backend_port is not None:
         app_data["backend_port"] = backend_port
+    if port_range is not None:
+        app_data["port_range"] = port_range
     if sni is not None:
         app_data["sni"] = sni
 

--- a/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
@@ -494,3 +494,180 @@ def test_requirer_application_data_proxy_protocol_enabled():
     data = TcpRequirerApplicationData(port=8080, proxy_protocol=True)
 
     assert data.proxy_protocol is True
+
+
+def test_port_range_valid():
+    """
+    arrange: Create a TcpRequirerApplicationData with a valid port_range.
+    act: Validate the model.
+    assert: Model validation passes.
+    """
+    data = TcpRequirerApplicationData(port_range="10500-10510", hosts=[MOCK_ADDRESS])
+
+    assert data.port_range == "10500-10510"
+    assert data.port is None
+
+
+def test_port_range_invalid_format():
+    """
+    arrange: Create a TcpRequirerApplicationData with a malformed port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="not-a-range", hosts=[MOCK_ADDRESS])
+
+
+def test_port_range_start_exceeds_end():
+    """
+    arrange: Create a TcpRequirerApplicationData with start > end in port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="10510-10500", hosts=[MOCK_ADDRESS])
+
+
+def test_port_range_out_of_bounds():
+    """
+    arrange: Create a TcpRequirerApplicationData with an invalid port number in port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="0-100", hosts=[MOCK_ADDRESS])
+
+
+def test_port_range_requires_at_least_one_of_port_or_range():
+    """
+    arrange: Create a TcpRequirerApplicationData with neither port nor port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(hosts=[MOCK_ADDRESS])
+
+
+def test_port_range_forbids_sni():
+    """
+    arrange: Create a TcpRequirerApplicationData with both port_range and sni.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(
+            port_range="10500-10510", sni="api.internal", hosts=[MOCK_ADDRESS]
+        )
+
+
+def test_port_range_self_overlap_with_port():
+    """
+    arrange: Create a TcpRequirerApplicationData where the port falls inside port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port=10505, port_range="10500-10510", hosts=[MOCK_ADDRESS])
+
+
+def test_port_range_self_overlap_with_backend_port():
+    """
+    arrange: Create a TcpRequirerApplicationData where backend_port falls inside port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(
+            port_range="10500-10510", backend_port=10505, hosts=[MOCK_ADDRESS]
+        )
+
+
+def test_check_ports_unique_range_overlap():
+    """
+    arrange: Create two requirers whose port_ranges overlap.
+    act: Construct HaproxyRouteTcpRequirersData.
+    assert: Both have relation IDs flagged in invalid_data_relation_ids.
+    """
+    requirer_a = HaproxyRouteTcpRequirerData(
+        relation_id=1,
+        application="app-a",
+        application_data=cast(
+            TcpRequirerApplicationData,
+            TcpRequirerApplicationData.from_dict(
+                {"port_range": "10500-10510", "hosts": ["10.0.0.1"]}
+            ),
+        ),
+        units_data=[
+            cast(TcpRequirerUnitData, TcpRequirerUnitData.from_dict({"address": "10.0.0.1"}))
+        ],
+    )
+    requirer_b = HaproxyRouteTcpRequirerData(
+        relation_id=2,
+        application="app-b",
+        application_data=cast(
+            TcpRequirerApplicationData,
+            TcpRequirerApplicationData.from_dict(
+                {"port_range": "10508-10515", "hosts": ["10.0.0.2"]}
+            ),
+        ),
+        units_data=[
+            cast(TcpRequirerUnitData, TcpRequirerUnitData.from_dict({"address": "10.0.0.2"}))
+        ],
+    )
+    data = HaproxyRouteTcpRequirersData(
+        requirers_data=[requirer_a, requirer_b],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    assert data.relation_ids_with_invalid_data == {1, 2}
+
+
+def test_check_ports_unique_range_and_port_overlap():
+    """
+    arrange: Create a port requirer and a port_range requirer where the port is inside the range.
+    act: Construct HaproxyRouteTcpRequirersData.
+    assert: Both relation IDs are flagged as invalid.
+    """
+    requirer_single = HaproxyRouteTcpRequirerData(
+        relation_id=1,
+        application="app-single",
+        application_data=cast(
+            TcpRequirerApplicationData,
+            TcpRequirerApplicationData.from_dict({"port": 10505, "hosts": ["10.0.0.1"]}),
+        ),
+        units_data=[
+            cast(TcpRequirerUnitData, TcpRequirerUnitData.from_dict({"address": "10.0.0.1"}))
+        ],
+    )
+    requirer_range = HaproxyRouteTcpRequirerData(
+        relation_id=2,
+        application="app-range",
+        application_data=cast(
+            TcpRequirerApplicationData,
+            TcpRequirerApplicationData.from_dict(
+                {"port_range": "10500-10510", "hosts": ["10.0.0.2"]}
+            ),
+        ),
+        units_data=[
+            cast(TcpRequirerUnitData, TcpRequirerUnitData.from_dict({"address": "10.0.0.2"}))
+        ],
+    )
+    data = HaproxyRouteTcpRequirersData(
+        requirers_data=[requirer_single, requirer_range],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    assert data.relation_ids_with_invalid_data == {1, 2}
+
+
+def test_expand_port_range():
+    """
+    arrange: A valid port range string.
+    act: Call expand_port_range.
+    assert: Returns the expected set of ports.
+    """
+    from charms.haproxy.v1.haproxy_route_tcp import expand_port_range
+
+    result = expand_port_range("10500-10503")
+
+    assert result == {10500, 10501, 10502, 10503}

--- a/haproxy-operator/tests/unit/test_state.py
+++ b/haproxy-operator/tests/unit/test_state.py
@@ -1827,3 +1827,156 @@ def test_haproxy_route_tcp_backend_servers_send_proxy_default(
     backend = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(haproxy_route_tcp)
 
     assert all(server.send_proxy is False for server in backend.servers)
+
+
+def test_port_range_frontend_properties(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Create a port_range backend.
+    act: Build the frontend and check properties.
+    assert: frontend_name, bind_address and all_frontend_ports reflect the range.
+    """
+    backend = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(
+        haproxy_route_tcp_relation_data(port_range="10500-10502")
+    )
+    frontend = HAProxyRouteTcpFrontend.from_backends([backend])
+
+    assert frontend.port_range == "10500-10502"
+    assert frontend.port is None
+    assert frontend.frontend_name == "haproxy_route_tcp_10500_10502"
+    assert frontend.bind_address == "10500-10502"
+    assert frontend.all_frontend_ports == [10500, 10501, 10502]
+
+
+def test_port_range_default_backend_name(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Create a port_range frontend.
+    act: Get default_backend_name.
+    assert: Uses range representation in the name.
+    """
+    backend = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(
+        haproxy_route_tcp_relation_data(port_range="10500-10502")
+    )
+    frontend = HAProxyRouteTcpFrontend.from_backends([backend])
+
+    assert frontend.default_backend_name == "haproxy_route_tcp_10500_10502_default_backend"
+
+
+def test_port_range_servers_are_portless(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Create a backend with port_range set.
+    act: Access the servers property.
+    assert: All servers have port=None for 1:1 passthrough.
+    """
+    backend = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(
+        haproxy_route_tcp_relation_data(port_range="10500-10502")
+    )
+
+    assert all(server.port is None for server in backend.servers)
+
+
+def test_port_range_frontend_all_frontend_ports_for_single_port(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Create a regular single-port frontend.
+    act: Get all_frontend_ports.
+    assert: Returns a one-element list with the single port.
+    """
+    backend = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(
+        haproxy_route_tcp_relation_data(port=4000)
+    )
+    frontend = HAProxyRouteTcpFrontend.from_backends([backend])
+
+    assert frontend.all_frontend_ports == [4000]
+
+
+def test_parse_haproxy_route_tcp_requirers_data_range_is_standalone(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Create a port_range requirer alongside a single-port requirer.
+    act: Call parse_haproxy_route_tcp_requirers_data.
+    assert: Two separate frontends are created; range frontend has port_range set.
+    """
+    requirers_data = HaproxyRouteTcpRequirersData(
+        requirers_data=[
+            haproxy_route_tcp_relation_data(
+                relation_id=0,
+                port=4000,
+                sni="api.example.com",
+                enforce_tls=True,
+                tls_terminate=True,
+            ),
+            haproxy_route_tcp_relation_data(
+                relation_id=1,
+                port_range="10500-10502",
+            ),
+        ],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    frontends = parse_haproxy_route_tcp_requirers_data(requirers_data)
+
+    assert len(frontends) == 2
+    range_frontends = [f for f in frontends if f.port_range is not None]
+    single_frontends = [f for f in frontends if f.port is not None]
+    assert len(range_frontends) == 1
+    assert len(single_frontends) == 1
+    assert range_frontends[0].port_range == "10500-10502"
+
+
+def test_valid_tcp_frontends_excludes_range_with_conflict(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Set up a port_range frontend whose range overlaps with an HTTP standard port.
+    act: Initialize HaproxyRouteRequirersInformation.
+    assert: The range frontend is excluded from valid_tcp_frontends.
+    """
+    haproxy_route_tcp_provider_mock = MagicMock()
+    haproxy_route_tcp_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteTcpRequirersData(
+            requirers_data=[
+                haproxy_route_tcp_relation_data(
+                    relation_id=0,
+                    port_range="79-81",
+                )
+            ],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+
+    haproxy_route_provider_mock = MagicMock()
+    haproxy_route_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteRequirersData(
+            requirers_data=[
+                haproxy_route_tcp_relation_data.__self__.__class__  # unused, just need HTTP flag
+            ]
+            if False
+            else [],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+    haproxy_route_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteRequirersData(
+            requirers_data=[],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+
+    haproxy_route_information = HaproxyRouteRequirersInformation.from_provider(
+        haproxy_route=haproxy_route_provider_mock,
+        haproxy_route_tcp=haproxy_route_tcp_provider_mock,
+        haproxy_route_policy=MagicMock(relation=None),
+        external_hostname="test.example.com",
+        peers=[],
+        ca_certs_configured=False,
+    )
+
+    assert len(haproxy_route_information.valid_tcp_frontends()) == 1


### PR DESCRIPTION
## Summary

Implements #525.

Adds a `port_range` attribute to `haproxy-route-tcp` (e.g. `"10500-10510"`), enabling requirer charms to map a contiguous range of frontend ports directly to the same ports on backend servers (1:1 plain TCP passthrough — no TLS termination or SNI inspection).

## Design

- `port` and `port_range` are mutually exclusive on a single relation; at least one is required.
- `sni` is forbidden when `port_range` is set (plain TCP only).
- HAProxy frontend is rendered with a range bind (`[::]:START-END v4v6`) and `tcp-request session set-dst-port fc_dst_port` to preserve the incoming destination port.
- Backend servers are rendered without an explicit port, so HAProxy uses the captured destination port for passthrough.
- Conflict detection expands ranges into individual ports when checking for cross-requirer and TCP/HTTP/gRPC overlaps.

## Changes

| File | What changed |
|------|-------------|
| `lib/charms/haproxy/v1/haproxy_route_tcp.py` | LIBPATCH 4→5; `port_range` field + validators; `expand_port_range` helper; `check_ports_unique` range expansion; `configure_port_range()` chaining method |
| `src/state/haproxy_route_tcp.py` | Portless `HaproxyRouteTcpServer.port`; `HAProxyRouteTcpFrontend.port_range`, `frontend_name`, `bind_address`, `all_frontend_ports` |
| `src/state/haproxy_route.py` | Standalone range frontends in parsing; range-aware conflict detection; `valid_tcp_frontends` checks `all_frontend_ports` |
| `templates/haproxy_route_tcp.cfg.j2` | Range bind; `set-dst-port fc_dst_port`; skip TLS/SNI blocks for ranges; portless server rendering |
| `src/charm.py` | `set_ports` iterates `all_frontend_ports`; endpoint publishing uses range string when set |
| `tests/` | New unit tests for validators, conflict detection, state parsing, frontend properties; integration requirer gets `update_relation_with_port_range()` |

## Testing

All local checks pass:
- `tox -e fmt` ✅
- `tox -e unit` ✅ (251 tests)
- `tox -e lint` ✅
- `tox -e static` ✅