### PR TITLE
feat: add port-range attribute to haproxy-route-tcp interface

### DIFF
--- a/docs/release-notes/artifacts/pr0538.yaml
+++ b/docs/release-notes/artifacts/pr0538.yaml
@@ -1,0 +1,14 @@
+# --- Release notes artifact ----
+
+schema_version: 1
+changes:
+  - title: Added port_range support to haproxy-route-tcp interface
+    author: github-actions[bot]
+    type: feature
+    description: The haproxy-route-tcp interface now supports a port_range attribute (e.g. "10500-10600") for 1-to-1 port mapping using HAProxy's bind range syntax.
+    urls:
+      pr: https://github.com/canonical/haproxy-operator/pull/538
+      related_doc:
+      related_issue: https://github.com/canonical/haproxy-operator/issues/525
+    visibility: public
+    highlight: false

--- a/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -708,10 +708,10 @@ class TcpRequirerApplicationData(_DatabagModel):
 
     @model_validator(mode="after")
     def validate_port_xor_port_range(self) -> "Self":
-        """Ensure exactly one of port or port_range is set.
+        """Ensure port and port_range are not both set.
 
         Raises:
-            ValueError: When neither or both port and port_range are set,
+            ValueError: When both port and port_range are set simultaneously,
                 or when port_range has an invalid format.
 
         Returns:
@@ -719,8 +719,8 @@ class TcpRequirerApplicationData(_DatabagModel):
         """
         port_set = self.port is not None
         port_range_set = self.port_range is not None
-        if port_set == port_range_set:
-            raise ValueError("Exactly one of 'port' or 'port_range' must be set.")
+        if port_set and port_range_set:
+            raise ValueError("Both 'port' and 'port_range' cannot be set simultaneously.")
         if self.port_range is not None:
             parse_port_range(self.port_range)
         return self
@@ -1000,13 +1000,18 @@ class HaproxyRouteTcpProvider(Object):
             RequirerApplicationData: Validated application data from the requirer.
         """
         try:
-            return cast(
+            data = cast(
                 TcpRequirerApplicationData,
                 TcpRequirerApplicationData.load(relation.data[relation.app]),
             )
         except DataValidationError:
             logger.error("Invalid requirer application data for %s", relation.app.name)
             raise
+        if data.port is None and data.port_range is None:
+            raise DataValidationError(
+                f"Requirer application data for {relation.app.name} has neither port nor port_range set."
+            )
+        return data
 
     def publish_proxied_endpoints(self, endpoints: list[str], relation: Relation) -> None:
         """Publish to the app databag the proxied endpoints.

--- a/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -157,7 +157,6 @@ class SomeCharm(CharmBase):
 
 import json
 import logging
-from collections import defaultdict
 from enum import Enum
 from typing import Annotated, Any, MutableMapping, Optional, cast
 
@@ -186,7 +185,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
@@ -235,6 +234,38 @@ def valid_domain_with_wildcard(value: str) -> str:
 
 
 VALIDSTR = Annotated[str, BeforeValidator(value_contains_invalid_characters)]
+
+PORT_RANGE_SEPARATOR = "-"
+PORT_MIN = 1
+PORT_MAX = 65535
+
+
+def parse_port_range(port_range: str) -> tuple[int, int]:
+    """Parse and validate a port range string in format 'start-end'.
+
+    Args:
+        port_range: Port range string in format 'start-end'.
+
+    Raises:
+        ValueError: When the port range string is invalid.
+
+    Returns:
+        tuple[int, int]: A (start, end) tuple of validated port numbers.
+    """
+    parts = port_range.split(PORT_RANGE_SEPARATOR)
+    if len(parts) != 2:
+        raise ValueError(f"port_range must be in format 'start{PORT_RANGE_SEPARATOR}end'")
+    try:
+        start, end = int(parts[0]), int(parts[1])
+    except ValueError as exc:
+        raise ValueError(f"port_range values must be integers, got: {port_range!r}") from exc
+    if not (PORT_MIN <= start <= PORT_MAX and PORT_MIN <= end <= PORT_MAX):
+        raise ValueError(
+            f"port_range values must be between {PORT_MIN} and {PORT_MAX}, got: {port_range!r}"
+        )
+    if start >= end:
+        raise ValueError(f"port_range start must be less than end, got: {port_range!r}")
+    return start, end
 
 
 class DataValidationError(Exception):
@@ -592,6 +623,9 @@ class TcpRequirerApplicationData(_DatabagModel):
 
     Attributes:
         port: The port exposed on the provider.
+        port_range: A range of ports to expose on the provider (format: 'start-end').
+            Mutually exclusive with port. When set, frontend ports are mapped 1-to-1
+            to the same ports on backend servers.
         backend_port: The port where the backend service is listening. Defaults to the
             provider port.
         hosts: List of backend server addresses. Currently only support IP addresses.
@@ -609,7 +643,17 @@ class TcpRequirerApplicationData(_DatabagModel):
         proxy_protocol: Whether to enable PROXY protocol when connecting to backend servers.
     """
 
-    port: int = Field(description="The port exposed on the provider.", gt=0, le=65535)
+    port: Optional[int] = Field(
+        description="The port exposed on the provider.", default=None, gt=0, le=65535
+    )
+    port_range: Optional[str] = Field(
+        description=(
+            "A range of ports to expose on the provider in format 'start-end'. "
+            "Mutually exclusive with port. When set, frontend ports are mapped 1-to-1 "
+            "to the same ports on backend servers (no port in server entries)."
+        ),
+        default=None,
+    )
     backend_port: Optional[int] = Field(
         description=(
             "The port where the backend service is listening. Defaults to the provider port."
@@ -663,14 +707,36 @@ class TcpRequirerApplicationData(_DatabagModel):
     )
 
     @model_validator(mode="after")
+    def validate_port_xor_port_range(self) -> "Self":
+        """Ensure exactly one of port or port_range is set.
+
+        Raises:
+            ValueError: When neither or both port and port_range are set,
+                or when port_range has an invalid format.
+
+        Returns:
+            The validated model.
+        """
+        port_set = self.port is not None
+        port_range_set = self.port_range is not None
+        if port_set == port_range_set:
+            raise ValueError("Exactly one of 'port' or 'port_range' must be set.")
+        if self.port_range is not None:
+            parse_port_range(self.port_range)
+        return self
+
+    @model_validator(mode="after")
     def assign_default_backend_port(self) -> "Self":
         """Assign a default value to backend_port if not set.
 
-        The value is equal to the provider port.
+        The value is equal to the provider port. Skipped when port_range is set,
+        since port-range backends use the frontend port for each connection.
 
         Returns:
             The model with backend_port default value applied.
         """
+        if self.port_range is not None:
+            return self
         if self.backend_port is None:
             self.backend_port = self.port
         return self
@@ -741,24 +807,31 @@ class HaproxyRouteTcpRequirersData:
 
     @model_validator(mode="after")
     def check_ports_unique(self) -> Self:
-        """Check that requirers define unique ports.
+        """Check that requirers define unique ports (including port ranges).
+
+        Detects conflicts between single ports and port ranges across all
+        requirers. If any port in a range overlaps with another requirer's
+        port or range, all conflicting relation IDs are marked as invalid.
 
         Returns:
             The validated model, with invalid relation IDs updated in
                 `self.relation_ids_with_invalid_data`
         """
-        # Maybe the logic here can be optimized, we want to keep track of
-        # the relation IDs that request overlapping ports to ignore them during
-        # rendering of the haproxy configuration.
-        relation_ids_per_port: dict[int, list[int]] = defaultdict(list[int])
+        port_to_relation_id: dict[int, int] = {}
         for requirer_data in self.requirers_data:
-            relation_ids_per_port[requirer_data.application_data.port].append(
-                requirer_data.relation_id
-            )
+            app_data = requirer_data.application_data
+            if app_data.port_range is not None:
+                start, end = parse_port_range(app_data.port_range)
+                ports: list[int] = list(range(start, end + 1))
+            else:
+                ports = [cast(int, app_data.port)]
 
-        for relation_ids in relation_ids_per_port.values():
-            if len(relation_ids) > 1:
-                self.relation_ids_with_invalid_data.update(relation_ids)
+            for port in ports:
+                if port in port_to_relation_id:
+                    self.relation_ids_with_invalid_data.add(port_to_relation_id[port])
+                    self.relation_ids_with_invalid_data.add(requirer_data.relation_id)
+                else:
+                    port_to_relation_id[port] = requirer_data.relation_id
         return self
 
 
@@ -983,6 +1056,7 @@ class HaproxyRouteTcpRequirer(Object):
         relation_name: str,
         *,
         port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1016,7 +1090,9 @@ class HaproxyRouteTcpRequirer(Object):
         Args:
             charm: The charm that is instantiating the library.
             relation_name: The name of the relation to bind to.
-            port: The provider port.
+            port: The provider port. Mutually exclusive with port_range.
+            port_range: A range of ports to expose (format: 'start-end').
+                Mutually exclusive with port. Maps frontend ports 1-to-1 to backend.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1059,6 +1135,7 @@ class HaproxyRouteTcpRequirer(Object):
         # build the full application data
         self._application_data = self._generate_application_data(
             port=port,
+            port_range=port_range,
             backend_port=backend_port,
             hosts=hosts,
             sni=sni,
@@ -1111,7 +1188,8 @@ class HaproxyRouteTcpRequirer(Object):
     def provide_haproxy_route_tcp_requirements(
         self,
         *,
-        port: int,
+        port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1143,7 +1221,9 @@ class HaproxyRouteTcpRequirer(Object):
         """Update haproxy-route requirements data in the relation.
 
         Args:
-            port: The provider port.
+            port: The provider port. Mutually exclusive with port_range.
+            port_range: A range of ports to expose (format: 'start-end').
+                Mutually exclusive with port. Maps frontend ports 1-to-1 to backend.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1179,6 +1259,7 @@ class HaproxyRouteTcpRequirer(Object):
         self._unit_address = unit_address
         self._application_data = self._generate_application_data(
             port=port,
+            port_range=port_range,
             backend_port=backend_port,
             hosts=hosts,
             sni=sni,
@@ -1213,6 +1294,7 @@ class HaproxyRouteTcpRequirer(Object):
         self,
         *,
         port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1243,7 +1325,9 @@ class HaproxyRouteTcpRequirer(Object):
         """Generate the complete application data structure.
 
         Args:
-            port: The provider port.
+            port: The provider port. Mutually exclusive with port_range.
+            port_range: A range of ports to expose (format: 'start-end').
+                Mutually exclusive with port.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1286,6 +1370,7 @@ class HaproxyRouteTcpRequirer(Object):
 
         application_data: dict[str, Any] = {
             "port": port,
+            "port_range": port_range,
             "backend_port": backend_port,
             "hosts": hosts,
             "sni": sni,

--- a/haproxy-operator/src/charm.py
+++ b/haproxy-operator/src/charm.py
@@ -418,8 +418,9 @@ class HAProxyCharm(ops.CharmBase):
             80,
             443,
             *(
-                frontend.port
+                Port(protocol="tcp", port=p)
                 for frontend in haproxy_route_requirers_information.valid_tcp_frontends()
+                for p in frontend.all_ports
             ),
             *(
                 backend.application_data.external_grpc_port
@@ -714,19 +715,25 @@ class HAProxyCharm(ops.CharmBase):
                         "The haproxy-route-tcp relation does not exist for this backend, skipping."
                     )
                     continue
-                if frontend.is_sni_routing_enabled:
+                if frontend.port_range is not None:
+                    start, end = frontend.port_range
+                    port_str = f"{start}-{end}"
+                elif frontend.is_sni_routing_enabled:
                     self.haproxy_route_tcp_provider.publish_proxied_endpoints(
                         [f"{backend.application_data.sni}:{frontend.port}"], relation
                     )
                     continue
+                else:
+                    port_str = str(frontend.port)
+
                 if ha_information.ha_integration_ready:
                     self.haproxy_route_tcp_provider.publish_proxied_endpoints(
-                        [f"{ha_information.vip}:{frontend.port}"], relation
+                        [f"{ha_information.vip}:{port_str}"], relation
                     )
                     continue
                 self.haproxy_route_tcp_provider.publish_proxied_endpoints(
                     [
-                        f"{unit_address}:{frontend.port}"
+                        f"{unit_address}:{port_str}"
                         for unit_address in self._get_peer_units_address()
                     ],
                     relation,

--- a/haproxy-operator/src/state/haproxy_route.py
+++ b/haproxy-operator/src/state/haproxy_route.py
@@ -631,7 +631,12 @@ class HaproxyRouteRequirersInformation:
             for backend in valid_backends
             if backend.application_data.external_grpc_port
         }
-        tcp_ports = {frontend.port: frontend for frontend in self.tcp_frontends}
+
+        # Build a port -> frontend map that expands port ranges
+        tcp_ports: dict[int, HAProxyRouteTcpFrontend] = {}
+        for frontend in self.tcp_frontends:
+            for p in frontend.all_ports:
+                tcp_ports[p] = frontend
 
         # Check for conflicts between standard HTTP and TCP/gRPC ports
         if has_http_backends:
@@ -686,7 +691,7 @@ class HaproxyRouteRequirersInformation:
         return [
             frontend
             for frontend in self.tcp_frontends
-            if frontend.port not in self.ports_with_conflicts
+            if not any(p in self.ports_with_conflicts for p in frontend.all_ports)
         ]
 
     @property
@@ -790,12 +795,14 @@ def parse_haproxy_route_tcp_requirers_data(
     Returns:
         list[HAProxyRouteTcpFrontend]: The parsed frontend data.
     """
-    port_to_backends_mapping: dict[int, list[HAProxyRouteTcpBackend]] = defaultdict(list)
+    frontend_key_to_backends_mapping: dict[str, list[HAProxyRouteTcpBackend]] = defaultdict(list)
     for requirer in tcp_requirers.requirers_data:
         endpoint = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(requirer)
-        port_to_backends_mapping[endpoint.application_data.port].append(endpoint)
+        app_data = endpoint.application_data
+        key = app_data.port_range if app_data.port_range is not None else str(app_data.port)
+        frontend_key_to_backends_mapping[key].append(endpoint)
     tcp_frontends: list[HAProxyRouteTcpFrontend] = []
-    for backends in port_to_backends_mapping.values():
+    for backends in frontend_key_to_backends_mapping.values():
         try:
             frontend = HAProxyRouteTcpFrontend.from_backends(backends)
             tcp_frontends.append(frontend)

--- a/haproxy-operator/src/state/haproxy_route_tcp.py
+++ b/haproxy-operator/src/state/haproxy_route_tcp.py
@@ -10,6 +10,7 @@ from charms.haproxy.v1.haproxy_route_tcp import (
     HaproxyRouteTcpRequirerData,
     TCPHealthCheckType,
     TCPServerHealthCheck,
+    parse_port_range,
 )
 from pydantic import Field, IPvAnyAddress
 from pydantic.dataclasses import dataclass
@@ -41,6 +42,7 @@ class HaproxyRouteTcpServer:
         server_name: The name of the unit with invalid characters replaced.
         address: The IP address of the requirer unit.
         port: The port that the requirer application wishes to be exposed.
+            None when port-range is used (HAProxy uses the frontend connection port).
         check: Health check configuration.
         maxconn: Maximum allowed connections before requests are queued.
         send_proxy: Whether to enable PROXY protocol for this server.
@@ -48,7 +50,7 @@ class HaproxyRouteTcpServer:
 
     server_name: str
     address: IPvAnyAddress
-    port: int
+    port: Optional[int]
     check: Optional[TCPServerHealthCheck]
     maxconn: Optional[int]
     send_proxy: bool = False
@@ -103,6 +105,9 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
         sequential server names and using the application's backend port and
         health check configuration.
 
+        When port_range is set, servers are created without a port so that
+        HAProxy maps the frontend port 1-to-1 to the backend.
+
         Returns:
             list[HaproxyRouteTcpServer]: List of configured backend servers.
         """
@@ -111,11 +116,16 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
         if not backend_addresses:
             backend_addresses = [unit_data.address for unit_data in self.units_data]
 
+        port = (
+            None
+            if self.application_data.port_range
+            else cast(int, self.application_data.backend_port)
+        )
         for i, address in enumerate(backend_addresses):
             servers.append(
                 HaproxyRouteTcpServer(
                     server_name=f"{self.application}-{i}",
-                    port=cast(int, self.application_data.backend_port),
+                    port=port,
                     address=address,
                     check=self.application_data.check,
                     maxconn=self.application_data.server_maxconn,
@@ -125,15 +135,30 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
         return servers
 
     @property
+    def port_range_tuple(self) -> Optional[tuple[int, int]]:
+        """Get the port range as a (start, end) tuple, or None for single-port backends.
+
+        Returns:
+            Optional[tuple[int, int]]: The (start, end) port range, or None.
+        """
+        if self.application_data.port_range is None:
+            return None
+        return parse_port_range(self.application_data.port_range)
+
+    @property
     def name(self) -> str:
         """Get the unique name for this TCP endpoint.
 
-        Combines the application name and frontend port to create a unique
-        identifier for the HAProxy configuration section.
+        Combines the application name and frontend port (or port range) to create
+        a unique identifier for the HAProxy configuration section.
 
         Returns:
-            str: The endpoint name in format "{application}_{port}".
+            str: The endpoint name in format "{application}_{port}" for single ports,
+                or "{application}_{start}_{end}" for port ranges.
         """
+        if port_range := self.application_data.port_range:
+            start, end = parse_port_range(port_range)
+            return f"{self.application}_{start}_{end}"
         return f"{self.application}_{self.application_data.port}"
 
     @property
@@ -194,19 +219,39 @@ class HAProxyRouteTcpFrontend:
     """A representation of a TCP frontend in the haproxy config.
 
     Attrs:
-        port: The port exposed on the provider.
+        port: The port exposed on the provider. None when port_range is set.
+        port_range: The (start, end) port range when multiple ports are mapped 1-to-1.
+            Mutually exclusive with port.
         backends: List of backend endpoints for this frontend.
         enforce_tls: Whether to enforce TLS for all traffic.
         tls_terminate: Whether to enable TLS termination.
     """
 
-    port: int = Field(description="The port exposed on the provider.", gt=0, le=65535)
     backends: list[HAProxyRouteTcpBackend] = Field(description="List of backend endpoints.")
+    port: Optional[int] = Field(
+        description="The port exposed on the provider.", default=None, gt=0, le=65535
+    )
+    port_range: Optional[tuple[int, int]] = Field(
+        description="The (start, end) port range for 1-to-1 port mapping.", default=None
+    )
     enforce_tls: bool = Field(description="Whether to enforce TLS for all traffic.", default=True)
     tls_terminate: bool = Field(description="Whether to enable tls termination.", default=True)
     relation_ids_with_invalid_data: set[int] = Field(
         description="List of relation ids with invalid data.", default=set[int]()
     )
+
+    @property
+    def all_ports(self) -> list[int]:
+        """Get all ports covered by this frontend.
+
+        Returns:
+            list[int]: A list with a single port for single-port frontends,
+                or all ports in the range for port-range frontends.
+        """
+        if self.port_range is not None:
+            start, end = self.port_range
+            return list(range(start, end + 1))
+        return [cast(int, self.port)]
 
     @classmethod
     def from_backends(cls, backends: list[HAProxyRouteTcpBackend]) -> "Self":
@@ -221,10 +266,13 @@ class HAProxyRouteTcpFrontend:
         Returns:
             Self: The instantiated HAProxyRouteTcpFrontend class.
         """
+        port_range = backends[0].port_range_tuple
+
         # If there's only one backend, return the class directly with values from the backend
         if len(backends) == 1:
             return cls(
                 port=backends[0].application_data.port,
+                port_range=port_range,
                 backends=backends,
                 enforce_tls=backends[0].application_data.enforce_tls,
                 tls_terminate=backends[0].application_data.tls_terminate,
@@ -263,6 +311,7 @@ class HAProxyRouteTcpFrontend:
             )
         return cls(
             port=rendered_backends[0].application_data.port,
+            port_range=port_range,
             backends=rendered_backends,
             enforce_tls=rendered_backends[0].application_data.enforce_tls,
             tls_terminate=rendered_backends[0].application_data.tls_terminate,
@@ -315,6 +364,9 @@ class HAProxyRouteTcpFrontend:
         Returns:
             str: The name of the default backend.
         """
+        if self.port_range is not None:
+            start, end = self.port_range
+            return f"haproxy_route_tcp_{start}_{end}_default_backend"
         return f"haproxy_route_tcp_{self.port}_default_backend"
 
     @property

--- a/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
@@ -1,7 +1,7 @@
 {% macro render_tcp_server(server) -%}
     server
 {{ server.server_name }}
-{{ server.address }}:{{ server.port }}
+{{ server.address }}{% if server.port is not none %}:{{ server.port }}{% endif %}
 {% if server.check %}
 check
 inter {{ server.check.interval }}s
@@ -17,10 +17,18 @@ send-proxy
 {%- endmacro %}
 
 {% for frontend in tcp_frontends %}
+{% if frontend.port_range %}
+frontend haproxy_route_tcp_{{ frontend.port_range[0] }}_{{ frontend.port_range[1] }}
+{% else %}
 frontend haproxy_route_tcp_{{ frontend.port }}
+{% endif %}
     mode tcp
     option tcplog
+{% if frontend.port_range %}
+    bind [::]:{{ frontend.port_range[0] }}-{{ frontend.port_range[1] }} v4v6 {% if frontend.tls_terminate %} ssl crt {{ haproxy_crt_dir }} {% endif +%}
+{% else %}
     bind [::]:{{ frontend.port }} v4v6 {% if frontend.tls_terminate %} ssl crt {{ haproxy_crt_dir }} {% endif +%}
+{% endif %}
 
 {# DDOS protection configuration. #}
 {% if ddos_protection_config.client_timeout %}

--- a/haproxy-operator/tests/unit/conftest.py
+++ b/haproxy-operator/tests/unit/conftest.py
@@ -461,7 +461,8 @@ def tcp_reconcile_context_fixture():
 
 def build_haproxy_route_tcp_relation(
     *,
-    port: int = 4000,
+    port: int | None = None,
+    port_range: str | None = None,
     backend_port: int | None = None,
     sni: str | None = None,
     enforce_tls: bool = True,
@@ -471,7 +472,8 @@ def build_haproxy_route_tcp_relation(
     """Build a scenario Relation for haproxy-route-tcp.
 
     Args:
-        port: Frontend port.
+        port: Frontend port. Mutually exclusive with port_range.
+        port_range: Port range string (e.g. "10500-10600"). Mutually exclusive with port.
         backend_port: Backend port (defaults to port).
         sni: Server Name Indication value.
         enforce_tls: Whether to enforce TLS.
@@ -481,11 +483,16 @@ def build_haproxy_route_tcp_relation(
     Returns:
         A scenario Relation for haproxy-route-tcp.
     """
+    if port is None and port_range is None:
+        port = 4000
     app_data: dict[str, str | int | bool | None] = {
-        "port": port,
         "enforce_tls": enforce_tls,
         "tls_terminate": tls_terminate,
     }
+    if port is not None:
+        app_data["port"] = port
+    if port_range is not None:
+        app_data["port_range"] = port_range
     if backend_port is not None:
         app_data["backend_port"] = backend_port
     if sni is not None:

--- a/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
@@ -562,10 +562,12 @@ def test_requirer_application_data_neither_port_nor_port_range():
     """
     arrange: Attempt to create data without port or port_range.
     act: Validate the model.
-    assert: ValidationError is raised.
+    assert: Model is created successfully with both port and port_range as None.
+        The provider is responsible for detecting this empty-databag state.
     """
-    with pytest.raises(ValidationError):
-        TcpRequirerApplicationData()
+    data = TcpRequirerApplicationData()
+    assert data.port is None
+    assert data.port_range is None
 
 
 def test_requirer_application_data_port_range_invalid_format():

--- a/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
@@ -494,3 +494,191 @@ def test_requirer_application_data_proxy_protocol_enabled():
     data = TcpRequirerApplicationData(port=8080, proxy_protocol=True)
 
     assert data.proxy_protocol is True
+
+
+def test_parse_port_range_valid():
+    """
+    arrange: Valid port range strings.
+    act: Call parse_port_range.
+    assert: Returns correct (start, end) tuple.
+    """
+    from charms.haproxy.v1.haproxy_route_tcp import parse_port_range
+
+    assert parse_port_range("10500-10600") == (10500, 10600)
+    assert parse_port_range("1-65535") == (1, 65535)
+    assert parse_port_range("8000-8099") == (8000, 8099)
+
+
+@pytest.mark.parametrize(
+    "invalid_range",
+    [
+        "notarange",
+        "8080",
+        "8080-",
+        "-8080",
+        "abc-def",
+        "10600-10500",
+        "10500-10500",
+        "0-8080",
+        "8080-65536",
+    ],
+)
+def test_parse_port_range_invalid(invalid_range):
+    """
+    arrange: Invalid port range strings.
+    act: Call parse_port_range.
+    assert: ValueError is raised.
+    """
+    from charms.haproxy.v1.haproxy_route_tcp import parse_port_range
+
+    with pytest.raises(ValueError):
+        parse_port_range(invalid_range)
+
+
+def test_requirer_application_data_port_range_valid():
+    """
+    arrange: Create a TcpRequirerApplicationData model with port_range.
+    act: Validate the model.
+    assert: port_range is set, port is None, backend_port is None.
+    """
+    data = TcpRequirerApplicationData(port_range="10500-10600")
+
+    assert data.port is None
+    assert data.port_range == "10500-10600"
+    assert data.backend_port is None
+
+
+def test_requirer_application_data_port_and_port_range_mutually_exclusive():
+    """
+    arrange: Attempt to set both port and port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port=8080, port_range="10500-10600")
+
+
+def test_requirer_application_data_neither_port_nor_port_range():
+    """
+    arrange: Attempt to create data without port or port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData()
+
+
+def test_requirer_application_data_port_range_invalid_format():
+    """
+    arrange: Create a TcpRequirerApplicationData model with invalid port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="not-a-range")
+
+
+def test_tcp_requirers_data_port_range_conflict():
+    """
+    arrange: Create HaproxyRouteTcpRequirersData where two requirers have overlapping port ranges.
+    act: Validate the model.
+    assert: Both relation IDs are added to relation_ids_with_invalid_data.
+    """
+    app_data1 = TcpRequirerApplicationData(port_range="10500-10600")
+    app_data2 = TcpRequirerApplicationData(port_range="10550-10650")
+
+    tcp_requirer_data1 = HaproxyRouteTcpRequirerData(
+        relation_id=1,
+        application_data=app_data1,
+        application="app1",
+        units_data=[TcpRequirerUnitData(address=MOCK_ADDRESS)],
+    )
+    tcp_requirer_data2 = HaproxyRouteTcpRequirerData(
+        relation_id=2,
+        application_data=app_data2,
+        application="app2",
+        units_data=[TcpRequirerUnitData(address=ANOTHER_MOCK_ADDRESS)],
+    )
+
+    requirers_data = HaproxyRouteTcpRequirersData(
+        requirers_data=[tcp_requirer_data1, tcp_requirer_data2],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    assert 1 in requirers_data.relation_ids_with_invalid_data
+    assert 2 in requirers_data.relation_ids_with_invalid_data
+
+
+def test_tcp_requirers_data_port_range_conflicts_with_single_port():
+    """
+    arrange: Create HaproxyRouteTcpRequirersData where a port range overlaps a single port.
+    act: Validate the model.
+    assert: Both relation IDs are added to relation_ids_with_invalid_data.
+    """
+    app_data1 = TcpRequirerApplicationData(port_range="10500-10600")
+    app_data2 = TcpRequirerApplicationData(port=10550)
+
+    tcp_requirer_data1 = HaproxyRouteTcpRequirerData(
+        relation_id=1,
+        application_data=app_data1,
+        application="app1",
+        units_data=[TcpRequirerUnitData(address=MOCK_ADDRESS)],
+    )
+    tcp_requirer_data2 = HaproxyRouteTcpRequirerData(
+        relation_id=2,
+        application_data=app_data2,
+        application="app2",
+        units_data=[TcpRequirerUnitData(address=ANOTHER_MOCK_ADDRESS)],
+    )
+
+    requirers_data = HaproxyRouteTcpRequirersData(
+        requirers_data=[tcp_requirer_data1, tcp_requirer_data2],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    assert 1 in requirers_data.relation_ids_with_invalid_data
+    assert 2 in requirers_data.relation_ids_with_invalid_data
+
+
+def test_tcp_requirers_data_non_overlapping_port_ranges():
+    """
+    arrange: Create HaproxyRouteTcpRequirersData with non-overlapping port ranges.
+    act: Validate the model.
+    assert: No relation IDs are added to relation_ids_with_invalid_data.
+    """
+    app_data1 = TcpRequirerApplicationData(port_range="10500-10600")
+    app_data2 = TcpRequirerApplicationData(port_range="10601-10700")
+
+    tcp_requirer_data1 = HaproxyRouteTcpRequirerData(
+        relation_id=1,
+        application_data=app_data1,
+        application="app1",
+        units_data=[TcpRequirerUnitData(address=MOCK_ADDRESS)],
+    )
+    tcp_requirer_data2 = HaproxyRouteTcpRequirerData(
+        relation_id=2,
+        application_data=app_data2,
+        application="app2",
+        units_data=[TcpRequirerUnitData(address=ANOTHER_MOCK_ADDRESS)],
+    )
+
+    requirers_data = HaproxyRouteTcpRequirersData(
+        requirers_data=[tcp_requirer_data1, tcp_requirer_data2],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    assert len(requirers_data.relation_ids_with_invalid_data) == 0
+
+
+def test_dump_and_load_port_range():
+    """
+    arrange: Create a TcpRequirerApplicationData model with port_range.
+    act: Dump and reload the model.
+    assert: port_range is preserved.
+    """
+    data = TcpRequirerApplicationData(port_range="10500-10600", enforce_tls=False)
+    databag = cast(dict[str, Any], data.dump())
+    loaded = cast(TcpRequirerApplicationData, TcpRequirerApplicationData.load(databag))
+
+    assert loaded.port_range == "10500-10600"
+    assert loaded.port is None

--- a/haproxy-operator/tests/unit/test_haproxy_route_tcp_proxied_endpoints.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_tcp_proxied_endpoints.py
@@ -291,3 +291,57 @@ def test_tcp_proxied_endpoints_sni_takes_priority_over_ha(
     out_tcp_relation = out.get_relation(tcp_relation.id)
     endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
     assert endpoints == ["api.example.com:4000"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_port_range(tcp_reconcile_context, peer_relation) -> None:
+    """
+    arrange: Create a haproxy-route-tcp relation with port_range configured.
+    act: Trigger config_changed as leader.
+    assert: Proxied endpoints are published as "{unit_address}:start-end".
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port_range="10500-10600",
+        enforce_tls=False,
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation],
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
+    assert endpoints == ["10.0.0.1:10500-10600"]
+
+
+@pytest.mark.usefixtures("systemd_mock", "mocks_external_calls")
+def test_tcp_proxied_endpoints_port_range_with_ha(tcp_reconcile_context, peer_relation) -> None:
+    """
+    arrange: Create a haproxy-route-tcp relation with port_range and HA configured.
+    act: Trigger config_changed as leader.
+    assert: Proxied endpoints are published as "{vip}:start-end".
+    """
+    context, _ = tcp_reconcile_context
+    tcp_relation = build_haproxy_route_tcp_relation(
+        port_range="10500-10600",
+        enforce_tls=False,
+    )
+    ha_relation = ops.testing.Relation(
+        endpoint="ha",
+        interface="hacluster",
+        remote_app_name="hacluster",
+    )
+
+    state = ops.testing.State(
+        relations=[peer_relation, tcp_relation, ha_relation],
+        config={"vip": "10.10.10.10"},
+        leader=True,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    out_tcp_relation = out.get_relation(tcp_relation.id)
+    endpoints = json.loads(out_tcp_relation.local_app_data["endpoints"])
+    assert endpoints == ["10.10.10.10:10500-10600"]


### PR DESCRIPTION
## Description

Implements #525 — adds a `port_range` attribute to the `haproxy-route-tcp` interface, allowing requirers to expose a range of ports (e.g. `"10500-10600"`) that are mapped 1-to-1 from frontend to backend.

### How it works

When a frontend uses `bind [::]:10500-10600`, HAProxy passes the destination port of each incoming connection to the backend. Backend server entries with **no port specified** inherit the frontend destination port, achieving 1-to-1 port mapping without explicit per-port configuration.

### Changes

- **Library** (`v1`, LIBPATCH→5): `parse_port_range()` helper, `port` made optional, `port_range: Optional[str]` field added with XOR validator (exactly one of `port`/`port_range` must be set), range-aware conflict detection expands ranges to individual ports before checking overlaps.
- **State** (`haproxy_route_tcp.py`): `HaproxyRouteTcpServer.port` is now `Optional[int]`; `HAProxyRouteTcpFrontend` gains `port_range: Optional[tuple[int,int]]` field and `all_ports` property returning all covered ports.
- **State** (`haproxy_route.py`): frontend grouping key is now a string (port number or range string); conflict detection and valid-frontend filtering use `all_ports` to expand ranges.
- **Template**: server macro omits `:port` when port is `None`; frontend section name uses `start_end` and bind line uses `start-end` (HAProxy syntax).
- **Charm**: `set_ports` expands port ranges; proxied endpoints for range frontends are published as `"host:start-end"`.
- **Tests**: 12 new library-level tests, 2 new proxied-endpoint tests, updated `build_haproxy_route_tcp_relation` fixture to accept `port_range`.

### Testing

```
254 tests pass, lint clean
```

Closes #525