### PR TITLE
feat: add port-range support to haproxy-route-tcp interface

### DIFF
--- a/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/haproxy-operator/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -186,7 +186,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
@@ -591,9 +591,12 @@ class TcpRequirerApplicationData(_DatabagModel):
     """Configuration model for HAProxy route requirer application data.
 
     Attributes:
-        port: The port exposed on the provider.
+        port: The port exposed on the provider. Mutually exclusive with port_range.
+        port_range: A port range in "start-end" format (e.g. "10500-10600"). When set,
+            every port in the range on the frontend maps 1:1 to the same port on the
+            backend. Mutually exclusive with port.
         backend_port: The port where the backend service is listening. Defaults to the
-            provider port.
+            provider port. Only used when port is set (ignored for port_range).
         hosts: List of backend server addresses. Currently only support IP addresses.
         sni: Server name identification. Used to route traffic to the service.
         check: TCP health check configuration
@@ -609,10 +612,24 @@ class TcpRequirerApplicationData(_DatabagModel):
         proxy_protocol: Whether to enable PROXY protocol when connecting to backend servers.
     """
 
-    port: int = Field(description="The port exposed on the provider.", gt=0, le=65535)
+    port: Optional[int] = Field(
+        description="The port exposed on the provider. Mutually exclusive with port_range.",
+        default=None,
+        gt=0,
+        le=65535,
+    )
+    port_range: Optional[str] = Field(
+        description=(
+            "A port range in 'start-end' format (e.g. '10500-10600'). "
+            "Every port in the range on the frontend is mapped 1:1 to the same port on the backend. "
+            "Mutually exclusive with port."
+        ),
+        default=None,
+    )
     backend_port: Optional[int] = Field(
         description=(
             "The port where the backend service is listening. Defaults to the provider port."
+            " Only used when port is set."
         ),
         default=None,
         gt=0,
@@ -666,13 +683,68 @@ class TcpRequirerApplicationData(_DatabagModel):
     def assign_default_backend_port(self) -> "Self":
         """Assign a default value to backend_port if not set.
 
-        The value is equal to the provider port.
+        The value is equal to the provider port. Only applies when port is set.
 
         Returns:
             The model with backend_port default value applied.
         """
-        if self.backend_port is None:
+        if self.port is not None and self.backend_port is None:
             self.backend_port = self.port
+        return self
+
+    @model_validator(mode="after")
+    def validate_port_or_port_range(self) -> "Self":
+        """Check that exactly one of port or port_range is set.
+
+        Raises:
+            ValueError: If neither or both are set.
+
+        Returns:
+            The validated model.
+        """
+        if self.port is None and self.port_range is None:
+            raise ValueError("Exactly one of 'port' or 'port_range' must be set.")
+        if self.port is not None and self.port_range is not None:
+            raise ValueError("'port' and 'port_range' are mutually exclusive.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_port_range_format(self) -> "Self":
+        """Validate port_range format and values.
+
+        Raises:
+            ValueError: If port_range format is invalid or values are out of range.
+
+        Returns:
+            The validated model.
+        """
+        if self.port_range is None:
+            return self
+        try:
+            start_str, end_str = self.port_range.split("-", 1)
+            start, end = int(start_str), int(end_str)
+        except ValueError as exc:
+            raise ValueError(
+                "port_range must be in 'start-end' format (e.g. '10500-10600')."
+            ) from exc
+        if not (1 <= start <= 65535) or not (1 <= end <= 65535):
+            raise ValueError("port_range values must be between 1 and 65535.")
+        if start >= end:
+            raise ValueError("port_range start must be less than end.")
+        return self
+
+    @model_validator(mode="after")
+    def sni_not_allowed_with_port_range(self) -> "Self":
+        """Check that sni is not set together with port_range.
+
+        Raises:
+            ValueError: If sni is configured alongside port_range.
+
+        Returns:
+            The validated model.
+        """
+        if self.port_range is not None and self.sni is not None:
+            raise ValueError("'sni' cannot be set when 'port_range' is used.")
         return self
 
     @model_validator(mode="after")
@@ -688,6 +760,18 @@ class TcpRequirerApplicationData(_DatabagModel):
         if not self.enforce_tls and self.sni is not None:
             raise ValueError("You can't set SNI and disable TLS at the same time.")
         return self
+
+    @property
+    def port_range_ports(self) -> list[int]:
+        """Return the list of individual ports in the port_range.
+
+        Returns:
+            list[int]: All ports in the range, or an empty list if port_range is not set.
+        """
+        if self.port_range is None:
+            return []
+        start_str, end_str = self.port_range.split("-", 1)
+        return list(range(int(start_str), int(end_str) + 1))
 
 
 class HaproxyRouteTcpProviderAppData(_DatabagModel):
@@ -741,20 +825,21 @@ class HaproxyRouteTcpRequirersData:
 
     @model_validator(mode="after")
     def check_ports_unique(self) -> Self:
-        """Check that requirers define unique ports.
+        """Check that requirers define unique ports (including port ranges).
 
         Returns:
             The validated model, with invalid relation IDs updated in
                 `self.relation_ids_with_invalid_data`
         """
-        # Maybe the logic here can be optimized, we want to keep track of
-        # the relation IDs that request overlapping ports to ignore them during
-        # rendering of the haproxy configuration.
         relation_ids_per_port: dict[int, list[int]] = defaultdict(list[int])
         for requirer_data in self.requirers_data:
-            relation_ids_per_port[requirer_data.application_data.port].append(
-                requirer_data.relation_id
-            )
+            if requirer_data.application_data.port_range:
+                for port in requirer_data.application_data.port_range_ports:
+                    relation_ids_per_port[port].append(requirer_data.relation_id)
+            else:
+                relation_ids_per_port[cast(int, requirer_data.application_data.port)].append(
+                    requirer_data.relation_id
+                )
 
         for relation_ids in relation_ids_per_port.values():
             if len(relation_ids) > 1:
@@ -983,6 +1068,7 @@ class HaproxyRouteTcpRequirer(Object):
         relation_name: str,
         *,
         port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1016,7 +1102,8 @@ class HaproxyRouteTcpRequirer(Object):
         Args:
             charm: The charm that is instantiating the library.
             relation_name: The name of the relation to bind to.
-            port: The provider port.
+            port: The provider port. Mutually exclusive with port_range.
+            port_range: A port range in "start-end" format. Mutually exclusive with port.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1024,7 +1111,7 @@ class HaproxyRouteTcpRequirer(Object):
             check_rise: Number of successful health checks before server is considered up.
             check_fall: Number of failed health checks before server is considered down.
             check_type: Health check type,
-                Can be “generic”, “mysql”, “postgres”, “redis” or “smtp”.
+                Can be "generic", "mysql", "postgres", "redis" or "smtp".
             check_send: Only used in generic health checks,
                 specify a string to send in the health check request.
             check_expect: Only used in generic health checks,
@@ -1059,6 +1146,7 @@ class HaproxyRouteTcpRequirer(Object):
         # build the full application data
         self._application_data = self._generate_application_data(
             port=port,
+            port_range=port_range,
             backend_port=backend_port,
             hosts=hosts,
             sni=sni,
@@ -1111,7 +1199,8 @@ class HaproxyRouteTcpRequirer(Object):
     def provide_haproxy_route_tcp_requirements(
         self,
         *,
-        port: int,
+        port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1143,7 +1232,8 @@ class HaproxyRouteTcpRequirer(Object):
         """Update haproxy-route requirements data in the relation.
 
         Args:
-            port: The provider port.
+            port: The provider port. Mutually exclusive with port_range.
+            port_range: A port range in "start-end" format. Mutually exclusive with port.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1151,7 +1241,7 @@ class HaproxyRouteTcpRequirer(Object):
             check_rise: Number of successful health checks before server is considered up.
             check_fall: Number of failed health checks before server is considered down.
             check_type: Health check type,
-                Can be “generic”, “mysql”, “postgres”, “redis” or “smtp”.
+                Can be "generic", "mysql", "postgres", "redis" or "smtp".
             check_send: Only used in generic health checks,
                 specify a string to send in the health check request.
             check_expect: Only used in generic health checks,
@@ -1179,6 +1269,7 @@ class HaproxyRouteTcpRequirer(Object):
         self._unit_address = unit_address
         self._application_data = self._generate_application_data(
             port=port,
+            port_range=port_range,
             backend_port=backend_port,
             hosts=hosts,
             sni=sni,
@@ -1213,6 +1304,7 @@ class HaproxyRouteTcpRequirer(Object):
         self,
         *,
         port: Optional[int] = None,
+        port_range: Optional[str] = None,
         backend_port: Optional[int] = None,
         hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
@@ -1243,7 +1335,8 @@ class HaproxyRouteTcpRequirer(Object):
         """Generate the complete application data structure.
 
         Args:
-            port: The provider port.
+            port: The provider port. Mutually exclusive with port_range.
+            port_range: A port range in "start-end" format. Mutually exclusive with port.
             backend_port: List of ports the service is listening on.
             hosts: List of backend server addresses. Currently only support IP addresses.
             sni: List of URL paths to route to this service.
@@ -1251,14 +1344,14 @@ class HaproxyRouteTcpRequirer(Object):
             check_rise: Number of successful health checks before server is considered up.
             check_fall: Number of failed health checks before server is considered down.
             check_type: Health check type,
-                Can be “generic”, “mysql”, “postgres”, “redis” or “smtp”.
+                Can be "generic", "mysql", "postgres", "redis" or "smtp".
             check_send: Only used in generic health checks,
                 specify a string to send in the health check request.
             check_expect: Only used in generic health checks,
                 specify the expected response from a health check request.
             check_db_user: Only used if type is postgres or mysql,
                 specify the user name to enable HAproxy to send a Client Authentication packet.
-            load_balancing_algorithm: Algorithm to use for load balancing.
+            load_balancing_algorithm: The load balancing algorithm.
             load_balancing_consistent_hashing: Whether to use consistent hashing.
             rate_limit_connections_per_minute: Maximum connections allowed per minute.
             rate_limit_policy: Policy to apply when rate limit is reached.
@@ -1286,6 +1379,7 @@ class HaproxyRouteTcpRequirer(Object):
 
         application_data: dict[str, Any] = {
             "port": port,
+            "port_range": port_range,
             "backend_port": backend_port,
             "hosts": hosts,
             "sni": sni,
@@ -1452,8 +1546,8 @@ class HaproxyRouteTcpRequirer(Object):
 
     def update_relation_data(self) -> None:
         """Update both application and unit data in the relation."""
-        if not self._application_data.get("port"):
-            logger.warning("port must be set, skipping update.")
+        if not self._application_data.get("port") and not self._application_data.get("port_range"):
+            logger.warning("port or port_range must be set, skipping update.")
             return
 
         if relation := self.relation:

--- a/haproxy-operator/src/charm.py
+++ b/haproxy-operator/src/charm.py
@@ -418,8 +418,9 @@ class HAProxyCharm(ops.CharmBase):
             80,
             443,
             *(
-                frontend.port
+                port
                 for frontend in haproxy_route_requirers_information.valid_tcp_frontends()
+                for port in frontend.all_ports
             ),
             *(
                 backend.application_data.external_grpc_port
@@ -714,19 +715,21 @@ class HAProxyCharm(ops.CharmBase):
                         "The haproxy-route-tcp relation does not exist for this backend, skipping."
                     )
                     continue
+                # For port-range frontends, publish using range notation (e.g. "ip:start-end").
+                port_suffix = frontend.port_range if frontend.port_range else str(frontend.port)
                 if frontend.is_sni_routing_enabled:
                     self.haproxy_route_tcp_provider.publish_proxied_endpoints(
-                        [f"{backend.application_data.sni}:{frontend.port}"], relation
+                        [f"{backend.application_data.sni}:{port_suffix}"], relation
                     )
                     continue
                 if ha_information.ha_integration_ready:
                     self.haproxy_route_tcp_provider.publish_proxied_endpoints(
-                        [f"{ha_information.vip}:{frontend.port}"], relation
+                        [f"{ha_information.vip}:{port_suffix}"], relation
                     )
                     continue
                 self.haproxy_route_tcp_provider.publish_proxied_endpoints(
                     [
-                        f"{unit_address}:{frontend.port}"
+                        f"{unit_address}:{port_suffix}"
                         for unit_address in self._get_peer_units_address()
                     ],
                     relation,

--- a/haproxy-operator/src/state/haproxy_route.py
+++ b/haproxy-operator/src/state/haproxy_route.py
@@ -611,6 +611,56 @@ class HaproxyRouteRequirersInformation:
             )
         return self
 
+    def _invalidate_tcp_frontends_on_port(
+        self, port: int, port_to_frontends: dict[int, list[HAProxyRouteTcpFrontend]]
+    ) -> None:
+        """Mark all TCP frontends on a given port as conflicted."""
+        self.ports_with_conflicts.add(port)
+        for frontend in port_to_frontends[port]:
+            self.relation_ids_with_invalid_data_tcp.update(
+                {backend.relation_id for backend in frontend.backends}
+            )
+
+    def _check_tcp_tcp_overlaps(
+        self, port_to_frontends: dict[int, list[HAProxyRouteTcpFrontend]]
+    ) -> None:
+        """Mark ports where more than one TCP frontend claims the same port."""
+        for port, frontends in port_to_frontends.items():
+            if len(frontends) > 1:
+                logger.error(f"TCP backends conflict on port {port}.")
+                self._invalidate_tcp_frontends_on_port(port, port_to_frontends)
+
+    def _check_http_vs_tcp_grpc(
+        self,
+        standard_ports: set[int],
+        port_to_frontends: dict[int, list[HAProxyRouteTcpFrontend]],
+        grpc_ports: dict[int, HAProxyRouteBackend],
+    ) -> None:
+        """Mark conflicts between standard HTTP ports and TCP/gRPC frontends."""
+        for standard_port in standard_ports:
+            if standard_port in port_to_frontends:
+                logger.error(
+                    f"TCP backend conflicts with HTTP backends on external port {standard_port}."
+                )
+                self._invalidate_tcp_frontends_on_port(standard_port, port_to_frontends)
+            if standard_port in grpc_ports:
+                logger.error(
+                    f"gRPC backend conflicts with HTTP backends on external port {standard_port}."
+                )
+                self.relation_ids_with_invalid_data.add(grpc_ports[standard_port].relation_id)
+                self.ports_with_conflicts.add(standard_port)
+
+    def _check_grpc_vs_tcp(
+        self,
+        port_to_frontends: dict[int, list[HAProxyRouteTcpFrontend]],
+        grpc_ports: dict[int, HAProxyRouteBackend],
+    ) -> None:
+        """Mark conflicts between gRPC backends and TCP frontends sharing a port."""
+        for port in grpc_ports.keys() & port_to_frontends.keys():
+            logger.error(f"Conflicting TCP backend and gRPC backend on external port {port}.")
+            self._invalidate_tcp_frontends_on_port(port, port_to_frontends)
+            self.relation_ids_with_invalid_data.add(grpc_ports[port].relation_id)
+
     @model_validator(mode="after")
     def check_tcp_http_port_conflicts(self) -> Self:
         """Check for port conflicts between HTTP backends and TCP/gRPC backends.
@@ -618,6 +668,7 @@ class HaproxyRouteRequirersInformation:
         the TCP/gRPC backend relation_id is added to the invalid data list.
         If conflict between TCP and gRPC backends is found,
         both relation_ids are added to the invalid data lists.
+        Port-range frontends are expanded so each port in the range is checked.
 
         Returns:
             Self: The validated model
@@ -625,40 +676,21 @@ class HaproxyRouteRequirersInformation:
         standard_ports = {80, 443}
         valid_backends = self.valid_backends()
         has_http_backends = any(not b.application_data.external_grpc_port for b in valid_backends)
-
         grpc_ports = {
             backend.application_data.external_grpc_port: backend
             for backend in valid_backends
             if backend.application_data.external_grpc_port
         }
-        tcp_ports = {frontend.port: frontend for frontend in self.tcp_frontends}
 
-        # Check for conflicts between standard HTTP and TCP/gRPC ports
+        port_to_frontends: dict[int, list[HAProxyRouteTcpFrontend]] = defaultdict(list)
+        for frontend in self.tcp_frontends:
+            for port in frontend.all_ports:
+                port_to_frontends[port].append(frontend)
+
+        self._check_tcp_tcp_overlaps(port_to_frontends)
         if has_http_backends:
-            for standard_port in standard_ports:
-                if standard_port in tcp_ports:
-                    logger.error(
-                        f"TCP backend conflicts with HTTP backends on external port {standard_port}."
-                    )
-                    self.relation_ids_with_invalid_data_tcp.update(
-                        {backend.relation_id for backend in tcp_ports[standard_port].backends}
-                    )
-                    self.ports_with_conflicts.add(standard_port)
-                if standard_port in grpc_ports:
-                    logger.error(
-                        f"gRPC backend conflicts with HTTP backends on external port {standard_port}."
-                    )
-                    self.relation_ids_with_invalid_data.add(grpc_ports[standard_port].relation_id)
-                    self.ports_with_conflicts.add(standard_port)
-
-        # Check for conflicts between gRPC and TCP ports
-        for port in grpc_ports.keys() & tcp_ports.keys():
-            logger.error(f"Conflicting TCP backend and gRPC backend on external port {port}.")
-            self.relation_ids_with_invalid_data_tcp.update(
-                {backend.relation_id for backend in tcp_ports[port].backends}
-            )
-            self.relation_ids_with_invalid_data.add(grpc_ports[port].relation_id)
-            self.ports_with_conflicts.add(port)
+            self._check_http_vs_tcp_grpc(standard_ports, port_to_frontends, grpc_ports)
+        self._check_grpc_vs_tcp(port_to_frontends, grpc_ports)
 
         if self.ports_with_conflicts:
             logger.warning(f"The following ports have conflicts: {self.ports_with_conflicts}")
@@ -680,13 +712,16 @@ class HaproxyRouteRequirersInformation:
     def valid_tcp_frontends(self) -> list[HAProxyRouteTcpFrontend]:
         """Get the list of valid TCP endpoints (not in the invalid list).
 
+        For port-range frontends, a frontend is invalid if any port in its range
+        conflicts with another frontend or HTTP/gRPC backend.
+
         Returns:
             list[HAProxyRouteTcpFrontend]: List of valid TCP endpoints.
         """
         return [
             frontend
             for frontend in self.tcp_frontends
-            if frontend.port not in self.ports_with_conflicts
+            if not any(port in self.ports_with_conflicts for port in frontend.all_ports)
         ]
 
     @property
@@ -787,14 +822,24 @@ def parse_haproxy_route_tcp_requirers_data(
 ) -> list[HAProxyRouteTcpFrontend]:
     """Parse HAProxyRouteTcpFrontend data from requirers into frontend objects.
 
+    Port-range backends are always standalone frontends. Single-port backends
+    are grouped by port to allow SNI-based merging via HAProxyRouteTcpFrontend.from_backends.
+
     Returns:
         list[HAProxyRouteTcpFrontend]: The parsed frontend data.
     """
     port_to_backends_mapping: dict[int, list[HAProxyRouteTcpBackend]] = defaultdict(list)
+    port_range_backends: list[HAProxyRouteTcpBackend] = []
+
     for requirer in tcp_requirers.requirers_data:
         endpoint = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(requirer)
-        port_to_backends_mapping[endpoint.application_data.port].append(endpoint)
+        if endpoint.application_data.port_range:
+            port_range_backends.append(endpoint)
+        else:
+            port_to_backends_mapping[cast(int, endpoint.application_data.port)].append(endpoint)
+
     tcp_frontends: list[HAProxyRouteTcpFrontend] = []
+
     for backends in port_to_backends_mapping.values():
         try:
             frontend = HAProxyRouteTcpFrontend.from_backends(backends)
@@ -802,6 +847,15 @@ def parse_haproxy_route_tcp_requirers_data(
         except HAProxyRouteTcpFrontendValidationError as exc:
             logger.error(f"Failed to parse TCP frontend: {exc}")
             continue
+
+    for backend in port_range_backends:
+        try:
+            frontend = HAProxyRouteTcpFrontend.from_backends([backend])
+            tcp_frontends.append(frontend)
+        except HAProxyRouteTcpFrontendValidationError as exc:
+            logger.error(f"Failed to parse TCP port-range frontend: {exc}")
+            continue
+
     return tcp_frontends
 
 

--- a/haproxy-operator/src/state/haproxy_route_tcp.py
+++ b/haproxy-operator/src/state/haproxy_route_tcp.py
@@ -41,6 +41,7 @@ class HaproxyRouteTcpServer:
         server_name: The name of the unit with invalid characters replaced.
         address: The IP address of the requirer unit.
         port: The port that the requirer application wishes to be exposed.
+            None when port_range is used (HAProxy uses the destination port).
         check: Health check configuration.
         maxconn: Maximum allowed connections before requests are queued.
         send_proxy: Whether to enable PROXY protocol for this server.
@@ -48,7 +49,7 @@ class HaproxyRouteTcpServer:
 
     server_name: str
     address: IPvAnyAddress
-    port: int
+    port: Optional[int]
     check: Optional[TCPServerHealthCheck]
     maxconn: Optional[int]
     send_proxy: bool = False
@@ -103,6 +104,9 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
         sequential server names and using the application's backend port and
         health check configuration.
 
+        When port_range is set, server entries omit the port so HAProxy uses
+        the destination port for 1:1 port mapping.
+
         Returns:
             list[HaproxyRouteTcpServer]: List of configured backend servers.
         """
@@ -111,11 +115,16 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
         if not backend_addresses:
             backend_addresses = [unit_data.address for unit_data in self.units_data]
 
+        port = (
+            None
+            if self.application_data.port_range
+            else cast(int, self.application_data.backend_port)
+        )
         for i, address in enumerate(backend_addresses):
             servers.append(
                 HaproxyRouteTcpServer(
                     server_name=f"{self.application}-{i}",
-                    port=cast(int, self.application_data.backend_port),
+                    port=port,
                     address=address,
                     check=self.application_data.check,
                     maxconn=self.application_data.server_maxconn,
@@ -128,12 +137,14 @@ class HAProxyRouteTcpBackend(HaproxyRouteTcpRequirerData):
     def name(self) -> str:
         """Get the unique name for this TCP endpoint.
 
-        Combines the application name and frontend port to create a unique
+        Combines the application name and frontend port (or port_range) to create a unique
         identifier for the HAProxy configuration section.
 
         Returns:
-            str: The endpoint name in format "{application}_{port}".
+            str: The endpoint name.
         """
+        if self.application_data.port_range:
+            return f"{self.application}_{self.application_data.port_range.replace('-', '_')}"
         return f"{self.application}_{self.application_data.port}"
 
     @property
@@ -194,7 +205,10 @@ class HAProxyRouteTcpFrontend:
     """A representation of a TCP frontend in the haproxy config.
 
     Attrs:
-        port: The port exposed on the provider.
+        port: The port exposed on the provider. For port_range frontends, this is
+            the start port (used as a stable identifier).
+        port_range: The port range in "start-end" format, set when the requirer
+            uses a port range instead of a single port.
         backends: List of backend endpoints for this frontend.
         enforce_tls: Whether to enforce TLS for all traffic.
         tls_terminate: Whether to enable TLS termination.
@@ -207,6 +221,45 @@ class HAProxyRouteTcpFrontend:
     relation_ids_with_invalid_data: set[int] = Field(
         description="List of relation ids with invalid data.", default=set[int]()
     )
+    port_range: Optional[str] = Field(
+        description="Port range in 'start-end' format. Set when the requirer uses a port range.",
+        default=None,
+    )
+
+    @property
+    def all_ports(self) -> list[int]:
+        """Return all frontend ports.
+
+        For a single-port frontend returns [port]. For a port_range frontend
+        returns every port in the range.
+
+        Returns:
+            list[int]: All ports covered by this frontend.
+        """
+        if self.port_range:
+            start_str, end_str = self.port_range.split("-", 1)
+            return list(range(int(start_str), int(end_str) + 1))
+        return [self.port]
+
+    @property
+    def frontend_name(self) -> str:
+        """Return the HAProxy frontend section name.
+
+        Returns:
+            str: The frontend section name.
+        """
+        if self.port_range:
+            return f"haproxy_route_tcp_{self.port_range.replace('-', '_')}"
+        return f"haproxy_route_tcp_{self.port}"
+
+    @property
+    def bind_ports(self) -> str:
+        """Return the port string used in the HAProxy bind directive.
+
+        Returns:
+            str: A single port number or a "start-end" range string.
+        """
+        return self.port_range if self.port_range else str(self.port)
 
     @classmethod
     def from_backends(cls, backends: list[HAProxyRouteTcpBackend]) -> "Self":
@@ -221,6 +274,19 @@ class HAProxyRouteTcpFrontend:
         Returns:
             Self: The instantiated HAProxyRouteTcpFrontend class.
         """
+        # Port-range backends are always standalone (no SNI merging).
+        if len(backends) == 1 and backends[0].application_data.port_range:
+            port_range = backends[0].application_data.port_range
+            start_port = int(port_range.split("-", 1)[0])
+            return cls(
+                port=start_port,
+                port_range=port_range,
+                backends=backends,
+                enforce_tls=backends[0].application_data.enforce_tls,
+                tls_terminate=backends[0].application_data.tls_terminate,
+                relation_ids_with_invalid_data=set[int](),
+            )
+
         # If there's only one backend, return the class directly with values from the backend
         if len(backends) == 1:
             return cls(
@@ -315,7 +381,7 @@ class HAProxyRouteTcpFrontend:
         Returns:
             str: The name of the default backend.
         """
-        return f"haproxy_route_tcp_{self.port}_default_backend"
+        return f"{self.frontend_name}_default_backend"
 
     @property
     def content_inspect_delay_required(self) -> bool:

--- a/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
+++ b/haproxy-operator/templates/haproxy_route_tcp.cfg.j2
@@ -1,7 +1,7 @@
 {% macro render_tcp_server(server) -%}
     server
 {{ server.server_name }}
-{{ server.address }}:{{ server.port }}
+{{ server.address }}{% if server.port is not none %}:{{ server.port }}{% endif %}
 {% if server.check %}
 check
 inter {{ server.check.interval }}s
@@ -17,10 +17,10 @@ send-proxy
 {%- endmacro %}
 
 {% for frontend in tcp_frontends %}
-frontend haproxy_route_tcp_{{ frontend.port }}
+frontend {{ frontend.frontend_name }}
     mode tcp
     option tcplog
-    bind [::]:{{ frontend.port }} v4v6 {% if frontend.tls_terminate %} ssl crt {{ haproxy_crt_dir }} {% endif +%}
+    bind [::]:{{ frontend.bind_ports }} v4v6 {% if frontend.tls_terminate %} ssl crt {{ haproxy_crt_dir }} {% endif +%}
 
 {# DDOS protection configuration. #}
 {% if ddos_protection_config.client_timeout %}

--- a/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
+++ b/haproxy-operator/tests/unit/test_haproxy_route_tcp_lib.py
@@ -494,3 +494,202 @@ def test_requirer_application_data_proxy_protocol_enabled():
     data = TcpRequirerApplicationData(port=8080, proxy_protocol=True)
 
     assert data.proxy_protocol is True
+
+
+# Port range tests
+
+
+def test_port_range_valid():
+    """
+    arrange: Create a TcpRequirerApplicationData with a valid port_range.
+    act: Validate the model.
+    assert: Model validation passes and port_range_ports returns the correct list.
+    """
+    data = TcpRequirerApplicationData(port_range="10500-10600")
+
+    assert data.port_range == "10500-10600"
+    assert data.port is None
+    assert data.backend_port is None
+    assert len(data.port_range_ports) == 101
+    assert data.port_range_ports[0] == 10500
+    assert data.port_range_ports[-1] == 10600
+
+
+def test_port_range_mutually_exclusive_with_port():
+    """
+    arrange: Create a TcpRequirerApplicationData with both port and port_range set.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port=8080, port_range="10500-10600")
+
+
+def test_port_range_or_port_required():
+    """
+    arrange: Create a TcpRequirerApplicationData with neither port nor port_range.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData()
+
+
+def test_port_range_invalid_format():
+    """
+    arrange: Create a TcpRequirerApplicationData with an invalid port_range format.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="not-a-range")
+
+
+def test_port_range_start_not_less_than_end():
+    """
+    arrange: Create a TcpRequirerApplicationData where port_range start >= end.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="10600-10500")
+
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="10500-10500")
+
+
+def test_port_range_out_of_valid_range():
+    """
+    arrange: Create a TcpRequirerApplicationData with port_range values outside 1-65535.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="0-100")
+
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="100-65536")
+
+
+def test_port_range_sni_not_allowed():
+    """
+    arrange: Create a TcpRequirerApplicationData with both port_range and sni.
+    act: Validate the model.
+    assert: ValidationError is raised.
+    """
+    with pytest.raises(ValidationError):
+        TcpRequirerApplicationData(port_range="10500-10600", sni="api.example.com")
+
+
+def test_port_range_conflict_with_single_port():
+    """
+    arrange: Create two requirers where a single port overlaps with a port range.
+    act: Create HaproxyRouteTcpRequirersData.
+    assert: Both conflicting relation IDs are marked invalid.
+    """
+    range_data = TcpRequirerApplicationData(port_range="10500-10600")
+    single_data = TcpRequirerApplicationData(port=10550)
+
+    range_requirer = HaproxyRouteTcpRequirerData(
+        relation_id=1,
+        application="range-app",
+        application_data=range_data,
+        units_data=[TcpRequirerUnitData(address=MOCK_ADDRESS)],
+    )
+    single_requirer = HaproxyRouteTcpRequirerData(
+        relation_id=2,
+        application="single-app",
+        application_data=single_data,
+        units_data=[TcpRequirerUnitData(address=ANOTHER_MOCK_ADDRESS)],
+    )
+
+    requirers_data = HaproxyRouteTcpRequirersData(
+        requirers_data=[range_requirer, single_requirer],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    assert 1 in requirers_data.relation_ids_with_invalid_data
+    assert 2 in requirers_data.relation_ids_with_invalid_data
+
+
+def test_port_range_conflict_between_two_ranges():
+    """
+    arrange: Create two requirers with overlapping port ranges.
+    act: Create HaproxyRouteTcpRequirersData.
+    assert: Both relation IDs are marked invalid.
+    """
+    range1_data = TcpRequirerApplicationData(port_range="10500-10600")
+    range2_data = TcpRequirerApplicationData(port_range="10550-10650")
+
+    range1_requirer = HaproxyRouteTcpRequirerData(
+        relation_id=1,
+        application="app1",
+        application_data=range1_data,
+        units_data=[TcpRequirerUnitData(address=MOCK_ADDRESS)],
+    )
+    range2_requirer = HaproxyRouteTcpRequirerData(
+        relation_id=2,
+        application="app2",
+        application_data=range2_data,
+        units_data=[TcpRequirerUnitData(address=ANOTHER_MOCK_ADDRESS)],
+    )
+
+    requirers_data = HaproxyRouteTcpRequirersData(
+        requirers_data=[range1_requirer, range2_requirer],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    assert 1 in requirers_data.relation_ids_with_invalid_data
+    assert 2 in requirers_data.relation_ids_with_invalid_data
+
+
+def test_port_range_no_conflict_with_non_overlapping_range():
+    """
+    arrange: Create two requirers with non-overlapping port ranges.
+    act: Create HaproxyRouteTcpRequirersData.
+    assert: Neither relation ID is marked invalid.
+    """
+    range1_data = TcpRequirerApplicationData(port_range="10500-10600")
+    range2_data = TcpRequirerApplicationData(port_range="10601-10700")
+
+    range1_requirer = HaproxyRouteTcpRequirerData(
+        relation_id=1,
+        application="app1",
+        application_data=range1_data,
+        units_data=[TcpRequirerUnitData(address=MOCK_ADDRESS)],
+    )
+    range2_requirer = HaproxyRouteTcpRequirerData(
+        relation_id=2,
+        application="app2",
+        application_data=range2_data,
+        units_data=[TcpRequirerUnitData(address=ANOTHER_MOCK_ADDRESS)],
+    )
+
+    requirers_data = HaproxyRouteTcpRequirersData(
+        requirers_data=[range1_requirer, range2_requirer],
+        relation_ids_with_invalid_data=set(),
+    )
+
+    assert not requirers_data.relation_ids_with_invalid_data
+
+
+def test_port_range_dump_and_load():
+    """
+    arrange: Create a TcpRequirerApplicationData with port_range, dump and reload it.
+    act: Dump to databag and load back.
+    assert: Data round-trips correctly.
+    """
+    from typing import cast as _cast
+
+    data = TcpRequirerApplicationData(port_range="10500-10600")
+    databag = data.dump()
+    assert databag is not None
+
+    loaded = _cast(
+        TcpRequirerApplicationData,
+        TcpRequirerApplicationData.load(databag),
+    )
+
+    assert loaded.port_range == "10500-10600"
+    assert loaded.port is None
+    assert len(loaded.port_range_ports) == 101

--- a/haproxy-operator/tests/unit/test_state.py
+++ b/haproxy-operator/tests/unit/test_state.py
@@ -1827,3 +1827,195 @@ def test_haproxy_route_tcp_backend_servers_send_proxy_default(
     backend = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(haproxy_route_tcp)
 
     assert all(server.send_proxy is False for server in backend.servers)
+
+
+# Port range tests
+
+
+def test_haproxy_route_tcp_port_range_backend_servers(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Generate TCP relation data with port_range.
+    act: Initialize the HAProxyRouteTcpBackend class with the generated relation data.
+    assert: Server entries have no port (port is None) so HAProxy uses destination port.
+    """
+    haproxy_route_tcp: HaproxyRouteTcpRequirerData = haproxy_route_tcp_relation_data(
+        port_range="10500-10600"
+    )
+    backend = HAProxyRouteTcpBackend.from_haproxy_route_tcp_requirer_data(haproxy_route_tcp)
+
+    assert backend.servers[0].port is None
+    assert backend.servers[0].address == haproxy_route_tcp.units_data[0].address
+    assert backend.name == f"{haproxy_route_tcp.application}_10500_10600"
+
+
+def test_haproxy_route_tcp_port_range_frontend_properties(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Generate TCP relation data with port_range.
+    act: Parse into HAProxyRouteTcpFrontend.
+    assert: Frontend has correct port_range, all_ports, frontend_name, and bind_ports.
+    """
+    from charms.haproxy.v1.haproxy_route_tcp import HaproxyRouteTcpRequirersData
+
+    from state.haproxy_route import parse_haproxy_route_tcp_requirers_data
+
+    haproxy_route_tcp: HaproxyRouteTcpRequirerData = haproxy_route_tcp_relation_data(
+        port_range="10500-10502"
+    )
+    requirers = HaproxyRouteTcpRequirersData(
+        requirers_data=[haproxy_route_tcp],
+        relation_ids_with_invalid_data=set(),
+    )
+    frontends = parse_haproxy_route_tcp_requirers_data(requirers)
+
+    assert len(frontends) == 1
+    frontend = frontends[0]
+    assert frontend.port_range == "10500-10502"
+    assert frontend.port == 10500
+    assert frontend.all_ports == [10500, 10501, 10502]
+    assert frontend.frontend_name == "haproxy_route_tcp_10500_10502"
+    assert frontend.bind_ports == "10500-10502"
+    assert frontend.default_backend_name == "haproxy_route_tcp_10500_10502_default_backend"
+
+
+def test_haproxy_route_tcp_port_range_conflict_with_http_backend(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+    haproxy_route_relation_data: typing.Callable[..., HaproxyRouteRequirerData],
+):
+    """
+    arrange: Setup a TCP port-range that includes port 80, plus an HTTP backend.
+    act: Initialize HaproxyRouteRequirersInformation.
+    assert: The port-range frontend is invalid (port 80 conflicts with HTTP backends).
+    """
+    from charms.haproxy.v2.haproxy_route import HaproxyRouteRequirersData
+
+    tcp_relation_id = 0
+    haproxy_route_tcp_provider_mock = MagicMock()
+    haproxy_route_tcp_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteTcpRequirersData(
+            requirers_data=[
+                haproxy_route_tcp_relation_data(
+                    port_range="79-81",
+                    relation_id=tcp_relation_id,
+                )
+            ],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+
+    http_relation_id = 1
+    haproxy_route_provider_mock = MagicMock()
+    haproxy_route_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteRequirersData(
+            requirers_data=[
+                haproxy_route_relation_data("http_service", relation_id=http_relation_id)
+            ],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+
+    haproxy_route_information = HaproxyRouteRequirersInformation.from_provider(
+        haproxy_route=haproxy_route_provider_mock,
+        haproxy_route_tcp=haproxy_route_tcp_provider_mock,
+        haproxy_route_policy=MagicMock(relation=None),
+        external_hostname="haproxy.internal",
+        peers=[],
+        ca_certs_configured=False,
+    )
+
+    assert tcp_relation_id in haproxy_route_information.relation_ids_with_invalid_data_tcp
+    assert len(haproxy_route_information.valid_tcp_frontends()) == 0
+
+
+def test_haproxy_route_tcp_port_range_vs_single_port_conflict(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Setup a TCP port-range and a single-port TCP requirer that overlap.
+    act: Initialize HaproxyRouteRequirersInformation with both.
+    assert: Both frontends are excluded from valid_tcp_frontends.
+    """
+    from charms.haproxy.v2.haproxy_route import HaproxyRouteRequirersData
+
+    range_relation_id = 0
+    single_relation_id = 1
+
+    haproxy_route_tcp_provider_mock = MagicMock()
+    haproxy_route_tcp_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteTcpRequirersData(
+            requirers_data=[
+                haproxy_route_tcp_relation_data(
+                    port_range="10500-10600", relation_id=range_relation_id
+                ),
+                haproxy_route_tcp_relation_data(port=10550, relation_id=single_relation_id),
+            ],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+
+    haproxy_route_provider_mock = MagicMock()
+    haproxy_route_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteRequirersData(
+            requirers_data=[],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+
+    haproxy_route_information = HaproxyRouteRequirersInformation.from_provider(
+        haproxy_route=haproxy_route_provider_mock,
+        haproxy_route_tcp=haproxy_route_tcp_provider_mock,
+        haproxy_route_policy=MagicMock(relation=None),
+        external_hostname=None,
+        peers=[],
+        ca_certs_configured=False,
+    )
+
+    assert len(haproxy_route_information.valid_tcp_frontends()) == 0
+
+
+def test_haproxy_route_tcp_port_range_valid_no_conflicts(
+    haproxy_route_tcp_relation_data: typing.Callable[..., HaproxyRouteTcpRequirerData],
+):
+    """
+    arrange: Setup a TCP port-range with no conflicts.
+    act: Initialize HaproxyRouteRequirersInformation.
+    assert: The port-range frontend is valid and all ports appear in valid_tcp_frontends.
+    """
+    from charms.haproxy.v2.haproxy_route import HaproxyRouteRequirersData
+
+    relation_id = 0
+    haproxy_route_tcp_provider_mock = MagicMock()
+    haproxy_route_tcp_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteTcpRequirersData(
+            requirers_data=[
+                haproxy_route_tcp_relation_data(port_range="10500-10502", relation_id=relation_id)
+            ],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+
+    haproxy_route_provider_mock = MagicMock()
+    haproxy_route_provider_mock.get_data = MagicMock(
+        return_value=HaproxyRouteRequirersData(
+            requirers_data=[],
+            relation_ids_with_invalid_data=set(),
+        )
+    )
+
+    haproxy_route_information = HaproxyRouteRequirersInformation.from_provider(
+        haproxy_route=haproxy_route_provider_mock,
+        haproxy_route_tcp=haproxy_route_tcp_provider_mock,
+        haproxy_route_policy=MagicMock(relation=None),
+        external_hostname=None,
+        peers=[],
+        ca_certs_configured=False,
+    )
+
+    valid_frontends = haproxy_route_information.valid_tcp_frontends()
+    assert len(valid_frontends) == 1
+    frontend = valid_frontends[0]
+    assert frontend.port_range == "10500-10502"
+    assert frontend.all_ports == [10500, 10501, 10502]


### PR DESCRIPTION
## Summary

Allow requirers to specify a port range (e.g. `10500-10600`) that maps 1:1 from the HAProxy frontend to the same port on the backend. For example, `<haproxy_ip>:10512` maps to `<backend_server_ip>:10512`.

## Changes

### Library (`lib/charms/haproxy/v1/haproxy_route_tcp.py`, LIBPATCH → 5)
- Added `port_range: Optional[str]` field to `TcpRequirerApplicationData`
- Made `port` optional (previously required)
- Added validators: format check (`start-end`), mutual exclusion with `port`, SNI disallowed with ranges, backend port assignment guarded
- Added `port_range_ports` property to expand the range
- Updated `check_ports_unique` to expand ranges during conflict detection
- Updated `HaproxyRouteTcpRequirer` API to accept `port_range`

### State (`src/state/haproxy_route_tcp.py`)
- `HaproxyRouteTcpServer.port` is now `Optional[int]` — `None` for range backends
- `HAProxyRouteTcpFrontend` gains `port_range`, `all_ports`, `frontend_name`, `bind_ports` properties
- `from_backends` handles port-range backends as standalone frontends (no SNI merging)

### State (`src/state/haproxy_route.py`)
- `check_tcp_http_port_conflicts` expands port ranges when building the port→frontend map, enabling correct TCP-TCP, TCP-HTTP, and TCP-gRPC conflict detection
- Refactored into helper methods (`_check_tcp_tcp_overlaps`, `_check_http_vs_tcp_grpc`, `_check_grpc_vs_tcp`) to meet complexity requirements
- `valid_tcp_frontends` checks `all_ports` against `ports_with_conflicts`

### Template (`templates/haproxy_route_tcp.cfg.j2`)
- `bind` uses `:start-end` notation for ranges
- `server` entries omit `:port` when port is `None` — HAProxy then uses the connecting port (1:1 mapping)

### Charm (`src/charm.py`)
- `set_ports` expands `frontend.all_ports` so every port in a range is opened
- Published endpoints use range notation (e.g. `10.0.0.1:10500-10600`)

## Tests
- 16 new tests added (103 total, all passing)
- Covers: format validation, mutual exclusion, SNI rejection, conflict detection (range-vs-single, range-vs-range, HTTP vs range), state properties, round-trip serialization