### PR TITLE
Update publish workflow for charm-ci

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -1,22 +1,45 @@
-name: Publish the haproxy-operator charm to edge
+name: Publish
 
 on:
-  workflow_dispatch:
   push:
     branches:
-    - main
+      - main
 
 jobs:
-  publish-to-edge:
-    strategy:
-      matrix:
-        configuration: [{working-directory: "./haproxy-operator", channel: "2.8/edge", tag-prefix: "haproxy"}, {working-directory: "./haproxy-spoe-auth-operator", channel: "latest/edge", tag-prefix: "haproxy-spoe-auth"}, {working-directory: "./haproxy-ddos-protection-configurator", channel: "latest/edge", tag-prefix: "haproxy-ddos-protection-configurator"}, {working-directory: "./haproxy-route-policy-operator", channel: "latest/edge", tag-prefix: "haproxy-route-policy"}]
+  publish:
+    uses: canonical/charm-ci/.github/workflows/publish-artifacts.yml@v0.0.1-alpha.2
     permissions:
       actions: read
       contents: write
-    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
-    secrets: inherit
     with:
-      channel: ${{ matrix.configuration.channel }}
-      working-directory: ${{ matrix.configuration.working-directory }}
-      tag-prefix: ${{ matrix.configuration.tag-prefix }}
+      channel: latest/edge
+      integration-workflow-name: integration_test.yaml
+    secrets:
+      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
+
+  release-libs:
+    name: Release any bumped charm library
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v6
+        with:
+          path: charm
+      - name: Release libraries
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"
+          CHARM_PATH: './haproxy-operator'
+          CHARM_NAME: 'haproxy'
+        run: |
+          sudo snap install charmcraft --classic
+          cd "${GITHUB_WORKSPACE}/charm/${CHARM_PATH}"
+          # Get the charm name
+          if [[ $CHARM_NAME = "" ]]; then echo "Error: empty charm name." && exit 1; fi
+          charmlib_path="${CHARM_NAME//-/_}"
+          # For each library belonging to the charm, publish it
+          if [ -d "lib/charms/${charmlib_path}" ]; then
+            for lib in $(find "lib/charms/${charmlib_path}" -type f | sed 's|lib/||' | sed 's/.py$//' | sed 's|/|.|g'); do
+              charmcraft publish-lib "$lib"
+            done
+          fi

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -12,7 +12,6 @@ jobs:
       actions: read
       contents: write
     with:
-      channel: latest/edge
       integration-workflow-name: integration_test.yaml
     secrets:
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,7 @@ terraform/**/*.tfstate*
 haproxy-route-policy/db.sqlite3
 haproxy-route-policy/.python-version
 
-**/.spread-reuse*
+# opcli/spread generated files
+.spread-reuse.*
+.spread-run-*/
+artifacts.build.yaml

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -11,6 +11,7 @@ charms:
   - arch: amd64
   - arch: arm64
     runner: [ubuntu-24.04-arm]
+  channel: latest/edge
 - name: haproxy
   charmcraft-yaml: haproxy-operator/charmcraft.yaml
   resources: {}
@@ -18,16 +19,19 @@ charms:
   - arch: amd64
   - arch: arm64
     runner: [ubuntu-24.04-arm]
+  channel: 2.8/edge
 - name: haproxy-route-policy
   charmcraft-yaml: haproxy-route-policy-operator/charmcraft.yaml
   resources: {}
   platforms:
   - arch: amd64
+  channel: latest/edge
 - name: haproxy-spoe-auth
   charmcraft-yaml: haproxy-spoe-auth-operator/charmcraft.yaml
   resources: {}
   platforms:
   - arch: amd64
+  channel: latest/edge
 snaps:
 - name: haproxy-route-policy
   snapcraft-yaml: haproxy-route-policy/snap/snapcraft.yaml


### PR DESCRIPTION
#### What this PR does

Following https://github.com/canonical/haproxy-operator/pull/547 we need to update the publish workflow to the new charm-ci.

Update the publish workflow and set the default channels for the charms.

#### Why we need it

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I added a [change artifact](../docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

