### PR TITLE
Revert snap to amd64 only and update charm-ci

### DIFF
--- a/.github/workflows/docs_spread.yaml
+++ b/.github/workflows/docs_spread.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   doc-test:
-    uses: canonical/charm-ci/.github/workflows/doc-test.yml@v0.0.1-alpha.2
+    uses: canonical/charm-ci/.github/workflows/doc-test.yml@v0.0.1-alpha.3
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   integration-test:
-    uses: canonical/charm-ci/.github/workflows/integration-test.yml@v0.0.1-alpha.2
+    uses: canonical/charm-ci/.github/workflows/integration-test.yml@v0.0.1-alpha.3
     with:
       spread-jobs-include: "integration-test-ci:*"
     secrets: inherit

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    uses: canonical/charm-ci/.github/workflows/publish-artifacts.yml@v0.0.1-alpha.2
+    uses: canonical/charm-ci/.github/workflows/publish-artifacts.yml@v0.0.1-alpha.3
     permissions:
       actions: read
       contents: write

--- a/haproxy-ddos-protection-configurator/pyproject.toml
+++ b/haproxy-ddos-protection-configurator/pyproject.toml
@@ -46,7 +46,7 @@ integration = [
   "jinja2==3.1.6",
   "jubilant==1.10.0",
   "juju==3.6.1.3",
-  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.2",
+  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.3",
   "protobuf==6.33.6",
   "pytest",
   "pytest-asyncio",

--- a/haproxy-ddos-protection-configurator/uv.lock
+++ b/haproxy-ddos-protection-configurator/uv.lock
@@ -1100,7 +1100,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#13721e4bead853b0449fe57019cd2c9aa6b75fdd" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/haproxy-ddos-protection-configurator/uv.lock
+++ b/haproxy-ddos-protection-configurator/uv.lock
@@ -610,7 +610,7 @@ integration = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "jubilant", specifier = "==1.10.0" },
     { name = "juju", specifier = "==3.6.1.3" },
-    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2" },
+    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3" },
     { name = "protobuf", specifier = "==6.33.6" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1100,7 +1100,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2#c0b3dc58a669bc27856c3655ffb4dee94c0abaac" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/haproxy-operator/pyproject.toml
+++ b/haproxy-operator/pyproject.toml
@@ -55,7 +55,7 @@ integration = [
   "jinja2==3.1.6",
   "jubilant==1.10.0",
   "juju==3.6.1.3",
-  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.2",
+  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.3",
   "protobuf==6.33.6",
   "playwright==1.60.0",
   "pytest",

--- a/haproxy-operator/uv.lock
+++ b/haproxy-operator/uv.lock
@@ -1233,7 +1233,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#13721e4bead853b0449fe57019cd2c9aa6b75fdd" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/haproxy-operator/uv.lock
+++ b/haproxy-operator/uv.lock
@@ -762,7 +762,7 @@ integration = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "jubilant", specifier = "==1.10.0" },
     { name = "juju", specifier = "==3.6.1.3" },
-    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2" },
+    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3" },
     { name = "playwright", specifier = "==1.60.0" },
     { name = "protobuf", specifier = "==6.33.6" },
     { name = "pytest" },
@@ -1233,7 +1233,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2#c0b3dc58a669bc27856c3655ffb4dee94c0abaac" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/haproxy-route-policy-operator/charmcraft.yaml
+++ b/haproxy-route-policy-operator/charmcraft.yaml
@@ -6,7 +6,6 @@ build-base: ubuntu@24.04
 
 platforms:
   amd64:
-  arm64:
 
 parts:
   charm:

--- a/haproxy-route-policy-operator/pyproject.toml
+++ b/haproxy-route-policy-operator/pyproject.toml
@@ -30,7 +30,7 @@ static = [ "bandit[toml]" ]
 integration = [
   "jubilant==1.10.0",
   "juju==3.6.1.3",
-  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.2",
+  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.3",
   "pytest",
   "pytest-operator",
 ]

--- a/haproxy-route-policy-operator/uv.lock
+++ b/haproxy-route-policy-operator/uv.lock
@@ -526,7 +526,7 @@ fmt = [{ name = "ruff" }]
 integration = [
     { name = "jubilant", specifier = "==1.10.0" },
     { name = "juju", specifier = "==3.6.1.3" },
-    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2" },
+    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3" },
     { name = "pytest" },
     { name = "pytest-operator" },
 ]
@@ -950,7 +950,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2#c0b3dc58a669bc27856c3655ffb4dee94c0abaac" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/haproxy-route-policy-operator/uv.lock
+++ b/haproxy-route-policy-operator/uv.lock
@@ -950,7 +950,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#13721e4bead853b0449fe57019cd2c9aa6b75fdd" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/haproxy-route-policy/snap/snapcraft.yaml
+++ b/haproxy-route-policy/snap/snapcraft.yaml
@@ -11,7 +11,6 @@ description: |
 confinement: strict
 platforms:
   amd64:
-  arm64:
 
 system-usernames:
   _daemon_: shared

--- a/haproxy-route-policy/snap/snapcraft.yaml
+++ b/haproxy-route-policy/snap/snapcraft.yaml
@@ -11,6 +11,8 @@ description: |
 confinement: strict
 platforms:
   amd64:
+    build-on: [amd64]
+    build-for: [amd64]
 
 system-usernames:
   _daemon_: shared

--- a/haproxy-spoe-auth-operator/charmcraft.yaml
+++ b/haproxy-spoe-auth-operator/charmcraft.yaml
@@ -4,6 +4,9 @@ type: charm
 base: ubuntu@24.04
 build-base: ubuntu@24.04
 
+platforms:
+  amd64:
+
 parts:
   charm:
     source: .

--- a/haproxy-spoe-auth-operator/charmcraft.yaml
+++ b/haproxy-spoe-auth-operator/charmcraft.yaml
@@ -4,10 +4,6 @@ type: charm
 base: ubuntu@24.04
 build-base: ubuntu@24.04
 
-platforms:
-  amd64:
-  arm64:
-
 parts:
   charm:
     source: .

--- a/haproxy-spoe-auth-operator/pyproject.toml
+++ b/haproxy-spoe-auth-operator/pyproject.toml
@@ -30,7 +30,7 @@ static = ["bandit[toml]"]
 integration = [
   "jubilant==1.10.0",
   "juju==3.6.1.3",
-  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.2",
+  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.3",
   "pytest",
   "pytest-operator",
 ]

--- a/haproxy-spoe-auth-operator/uv.lock
+++ b/haproxy-spoe-auth-operator/uv.lock
@@ -521,7 +521,7 @@ fmt = [{ name = "ruff" }]
 integration = [
     { name = "jubilant", specifier = "==1.10.0" },
     { name = "juju", specifier = "==3.6.1.3" },
-    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2" },
+    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3" },
     { name = "pytest" },
     { name = "pytest-operator" },
 ]
@@ -910,7 +910,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2#c0b3dc58a669bc27856c3655ffb4dee94c0abaac" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/haproxy-spoe-auth-operator/uv.lock
+++ b/haproxy-spoe-auth-operator/uv.lock
@@ -910,7 +910,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#13721e4bead853b0449fe57019cd2c9aa6b75fdd" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/haproxy-spoe-auth-snap/snapcraft.yaml
+++ b/haproxy-spoe-auth-snap/snapcraft.yaml
@@ -12,7 +12,8 @@ description: |
 
 platforms:
   amd64:
-  arm64:
+    build-on: [amd64]
+    build-for: [amd64]
 
 grade: stable
 confinement: strict

--- a/haproxy-spoe-auth-snap/snapcraft.yaml
+++ b/haproxy-spoe-auth-snap/snapcraft.yaml
@@ -10,11 +10,6 @@ description: |
   A SPOE (Stream Processing Offload Engine) agent for HAProxy that provides
   authentication capabilities.
 
-platforms:
-  amd64:
-    build-on: [amd64]
-    build-for: [amd64]
-
 grade: stable
 confinement: strict
 parts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ integration = [
   "jinja2==3.1.6",
   "jubilant==1.10.0",
   "juju==3.6.1.3",
-  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.2",
+  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.3",
   "protobuf==6.33.6",
   "playwright==1.60.0",
   "pytest",

--- a/uv.lock
+++ b/uv.lock
@@ -1014,7 +1014,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#13721e4bead853b0449fe57019cd2c9aa6b75fdd" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ integration = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "jubilant", specifier = "==1.10.0" },
     { name = "juju", specifier = "==3.6.1.3" },
-    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2" },
+    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3" },
     { name = "playwright", specifier = "==1.60.0" },
     { name = "protobuf", specifier = "==6.33.6" },
     { name = "pytest" },
@@ -1014,7 +1014,7 @@ wheels = [
 [[package]]
 name = "opcli"
 version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.2#c0b3dc58a669bc27856c3655ffb4dee94c0abaac" }
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.3#2a0651db53eab9b0797bb82c94dba746705aae64" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },


### PR DESCRIPTION
#### What this PR does

Revert snap to be only amd64. The charm is not adapted, and the publish fails, so no need for now.

Update charm-ci to fix the publish.

#### Why we need it

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I added a [change artifact](../docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

