### PR TITLE
feat(terraform)!: convert provides/requires to map(object) per CC008 (breaking)

### DIFF
--- a/terraform/charm/haproxy/outputs.tf
+++ b/terraform/charm/haproxy/outputs.tf
@@ -11,19 +11,61 @@ output "application" {
 }
 
 output "provides" {
+  description = "Map of provided endpoints."
   value = {
-    ingress       = "ingress"
-    haproxy_route = "haproxy-route"
-    cos_agent     = "cos-agent"
-    spoe_auth     = "spoe-auth"
+    cos_agent = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy.name
+      endpoint   = "cos-agent"
+      controller = null
+    }
+    haproxy_route = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy.name
+      endpoint   = "haproxy-route"
+      controller = null
+    }
+    ingress = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy.name
+      endpoint   = "ingress"
+      controller = null
+    }
+    spoe_auth = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy.name
+      endpoint   = "spoe-auth"
+      controller = null
+    }
   }
 }
 
 output "requires" {
+  description = "Map of required endpoints."
   value = {
-    certificates     = "certificates"
-    receive_ca_certs = "receive-ca-certs"
-    reverseproxy     = "reverseproxy"
-    ddos_protection  = "ddos-protection"
+    certificates = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy.name
+      endpoint   = "certificates"
+      controller = null
+    }
+    ddos_protection = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy.name
+      endpoint   = "ddos-protection"
+      controller = null
+    }
+    receive_ca_certs = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy.name
+      endpoint   = "receive-ca-certs"
+      controller = null
+    }
+    reverseproxy = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy.name
+      endpoint   = "reverseproxy"
+      controller = null
+    }
   }
 }

--- a/terraform/charm/haproxy_ddos_protection_configurator/outputs.tf
+++ b/terraform/charm/haproxy_ddos_protection_configurator/outputs.tf
@@ -11,11 +11,18 @@ output "application" {
 }
 
 output "provides" {
+  description = "Map of provided endpoints."
   value = {
-    ddos_protection = "ddos-protection"
+    ddos_protection = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy_ddos_protection_configurator.name
+      endpoint   = "ddos-protection"
+      controller = null
+    }
   }
 }
 
 output "requires" {
-  value = {}
+  description = "Map of required endpoints."
+  value       = {}
 }

--- a/terraform/charm/haproxy_spoe_auth/outputs.tf
+++ b/terraform/charm/haproxy_spoe_auth/outputs.tf
@@ -11,13 +11,25 @@ output "application" {
 }
 
 output "provides" {
+  description = "Map of provided endpoints."
   value = {
-    spoe_auth = "spoe-auth"
+    spoe_auth = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy_spoe_auth.name
+      endpoint   = "spoe-auth"
+      controller = null
+    }
   }
 }
 
 output "requires" {
+  description = "Map of required endpoints."
   value = {
-    oauth = "oauth"
+    oauth = {
+      kind       = "endpoint"
+      name       = juju_application.haproxy_spoe_auth.name
+      endpoint   = "oauth"
+      controller = null
+    }
   }
 }

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -50,7 +50,7 @@ resource "juju_integration" "grafana_agent" {
 
   application {
     name     = module.haproxy.app_name
-    endpoint = module.haproxy.provides.cos_agent
+    endpoint = module.haproxy.provides.cos_agent.endpoint
   }
 
   application {
@@ -77,12 +77,12 @@ resource "juju_integration" "haproxy_haproxy_ddos_protection_configurator" {
 
   application {
     name     = module.haproxy_ddos_protection_configurator.app_name
-    endpoint = module.haproxy_ddos_protection_configurator.provides.ddos_protection
+    endpoint = module.haproxy_ddos_protection_configurator.provides.ddos_protection.endpoint
   }
 
   application {
     name     = module.haproxy.app_name
-    endpoint = module.haproxy.requires.ddos_protection
+    endpoint = module.haproxy.requires.ddos_protection.endpoint
   }
 }
 
@@ -110,12 +110,12 @@ resource "juju_integration" "haproxy_spoe_auth" {
 
   application {
     name     = each.value.app_name
-    endpoint = each.value.provides.spoe_auth
+    endpoint = each.value.provides.spoe_auth.endpoint
   }
 
   application {
     name     = module.haproxy.app_name
-    endpoint = module.haproxy.provides.spoe_auth
+    endpoint = module.haproxy.provides.spoe_auth.endpoint
   }
 }
 

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -54,20 +54,67 @@ output "models" {
 }
 
 output "provides" {
+  description = "Map of provided endpoints."
   value = {
-    ingress          = "ingress"
-    haproxy_route    = "haproxy-route"
-    logging_provider = "logging-provider"
+    haproxy_route = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "haproxy-route"
+      controller = null
+    }
+    ingress = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "ingress"
+      controller = null
+    }
+    logging_provider = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "logging-provider"
+      controller = null
+    }
   }
 }
 
 output "requires" {
+  description = "Map of required endpoints."
   value = {
-    reverseproxy                = "reverseproxy"
-    certificates                = "certificates"
-    receive_ca_certs            = "receive-ca-certs"
-    metrics_endpoint            = "metrics-endpoint"
-    send_remote_write           = "send-remote-write"
-    grafana_dashboards_consumer = "grafana-dashboards-consumer"
+    certificates = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "certificates"
+      controller = null
+    }
+    grafana_dashboards_consumer = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "grafana-dashboards-consumer"
+      controller = null
+    }
+    metrics_endpoint = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "metrics-endpoint"
+      controller = null
+    }
+    receive_ca_certs = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "receive-ca-certs"
+      controller = null
+    }
+    reverseproxy = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "reverseproxy"
+      controller = null
+    }
+    send_remote_write = {
+      kind       = "endpoint"
+      name       = module.haproxy.app_name
+      endpoint   = "send-remote-write"
+      controller = null
+    }
   }
 }

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -65,7 +65,7 @@ variable "keepalived" {
 variable "metadata_version" {
   description = "Version string reported in the product module 'metadata' output."
   type        = string
-  default     = "0.0.0"
+  default     = "1.0.0"
 }
 
 variable "model_uuid" {

--- a/terraform/tests/main.tftest.hcl
+++ b/terraform/tests/main.tftest.hcl
@@ -80,7 +80,7 @@ run "basic_deploy" {
   }
 
   assert {
-    condition     = output.metadata.version == "0.0.0"
-    error_message = "metadata.version should default to 0.0.0"
+    condition     = output.metadata.version == "1.0.0"
+    error_message = "metadata.version should default to 1.0.0"
   }
 }


### PR DESCRIPTION
#### What this PR does

Converts the `provides` and `requires` outputs of all charm and product modules from `map(string)` to `map(object)` per the CC008 (Charm Terraform Standards) specification, including the 26.04-post cross-controller additions.

**New shape for every entry:**
```hcl
haproxy_route = {
  kind       = "endpoint"   # "endpoint" | "offer" — enables cross-controller relations
  name       = "haproxy"    # juju_application name that owns the endpoint
  endpoint   = "haproxy-route"
  controller = null         # optional: cross-controller alias; always null for in-model
}
```

**Files changed:**
- `terraform/charm/haproxy/outputs.tf` — provides (cos_agent, haproxy_route, ingress, spoe_auth) + requires (certificates, ddos_protection, receive_ca_certs, reverseproxy)
- `terraform/charm/haproxy_spoe_auth/outputs.tf` — provides + requires
- `terraform/charm/haproxy_ddos_protection_configurator/outputs.tf` — provides + requires
- `terraform/product/main.tf` — 5 internal `juju_integration` endpoint consumers updated to `.endpoint` (lockstep)
- `terraform/product/outputs.tf` — product-level provides + requires

#### Why we need it

CC008 mandates `provides`/`requires` as `map(object)` so that consumers can wire integrations using the structured output (no need to hard-code endpoint or app names externally) and to support cross-controller relations via the `kind`/`controller` fields.

#### Breaking changes

This is a **major-version breaking change**. Any caller currently reading endpoint names as plain strings (e.g. `module.haproxy.provides.haproxy_route` used directly as a string) must be updated to `module.haproxy.provides.haproxy_route.endpoint`. The internal `terraform/product/main.tf` consumer is updated in this PR.

Follow-up PR #590 (non-breaking outputs/inputs) is independent and can be merged in either order.

#### Test plan

- `terraform fmt -check -recursive` — passes
- `terraform validate` on all 4 modules — `Success!`
- `tflint` — runs in CI
- `terraform test` — runs in CI (`test_terraform_module.yaml`, needs live Juju controller)

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated tests as needed
- [x] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [x] I used AI to assist with preparing this PR
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I added a change artifact / tagged `no-release-note`