### PR TITLE
Support juju 4 in integration tests

### DIFF
--- a/haproxy-operator/tests/integration/conftest.py
+++ b/haproxy-operator/tests/integration/conftest.py
@@ -108,7 +108,7 @@ def certificate_provider_application_fixture(
         logger.warning("Using existing application: %s", SELF_SIGNED_CERTIFICATES_APP_NAME)
         return SELF_SIGNED_CERTIFICATES_APP_NAME
     juju.deploy(
-        "self-signed-certificates", app=SELF_SIGNED_CERTIFICATES_APP_NAME, channel="1/edge"
+        "self-signed-certificates", app=SELF_SIGNED_CERTIFICATES_APP_NAME, channel="1/edge", force=True
     )
     return SELF_SIGNED_CERTIFICATES_APP_NAME
 

--- a/haproxy-operator/tests/integration/helper.py
+++ b/haproxy-operator/tests/integration/helper.py
@@ -198,10 +198,10 @@ def get_http_version_from_apache2_logs(
     Returns:
         The extracted HTTP version string.
     """
-    last_httpx_log_entry = juju.ssh(
-        f"{app_name}/0",
+    last_httpx_log_entry = juju.exec(
         f"grep '{request_id}' /var/log/apache2/access.log | tail -n 1",
-    )
+        unit=f"{app_name}/0",
+    ).stdout
 
     match = pattern.search(last_httpx_log_entry)
     if not match:

--- a/haproxy-operator/tests/integration/test_haproxy_route.py
+++ b/haproxy-operator/tests/integration/test_haproxy_route.py
@@ -51,9 +51,9 @@ def test_haproxy_route_any_charm_requirer(
             status, configured_application_with_tls, any_charm_haproxy_route_requirer
         )
     )
-    haproxy_config = juju.ssh(
-        f"{configured_application_with_tls}/0", "cat /etc/haproxy/haproxy.cfg"
-    )
+    haproxy_config = juju.exec(
+        "cat /etc/haproxy/haproxy.cfg", unit=f"{configured_application_with_tls}/0"
+    ).stdout
     assert all(
         entry in haproxy_config
         for entry in [

--- a/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
+++ b/haproxy-operator/tests/integration/test_haproxy_route_tcp.py
@@ -61,9 +61,9 @@ def test_haproxy_route_tcp(
         )
     )
 
-    haproxy_config = juju.ssh(
-        f"{configured_application_with_tls}/0", "cat /etc/haproxy/haproxy.cfg"
-    )
+    haproxy_config = juju.exec(
+        "cat /etc/haproxy/haproxy.cfg", unit=f"{configured_application_with_tls}/0"
+    ).stdout
     assert all(
         entry in haproxy_config
         for entry in [
@@ -86,9 +86,9 @@ def test_haproxy_route_tcp(
         )
     )
 
-    haproxy_config = juju.ssh(
-        f"{configured_application_with_tls}/0", "cat /etc/haproxy/haproxy.cfg"
-    )
+    haproxy_config = juju.exec(
+        "cat /etc/haproxy/haproxy.cfg", unit=f"{configured_application_with_tls}/0"
+    ).stdout
     assert all(
         entry in haproxy_config
         for entry in [
@@ -110,9 +110,9 @@ def test_haproxy_route_tcp(
         )
     )
 
-    haproxy_config = juju.ssh(
-        f"{configured_application_with_tls}/0", "cat /etc/haproxy/haproxy.cfg"
-    )
+    haproxy_config = juju.exec(
+        "cat /etc/haproxy/haproxy.cfg", unit=f"{configured_application_with_tls}/0"
+    ).stdout
     assert "send-proxy" in haproxy_config
 
     # Test with port range binding
@@ -127,7 +127,7 @@ def test_haproxy_route_tcp(
         )
     )
 
-    haproxy_config = juju.ssh(
-        f"{configured_application_with_tls}/0", "cat /etc/haproxy/haproxy.cfg"
-    )
+    haproxy_config = juju.exec(
+        "cat /etc/haproxy/haproxy.cfg", unit=f"{configured_application_with_tls}/0"
+    ).stdout
     assert "bind [::]:8080-8090" in haproxy_config

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -217,6 +217,7 @@ def certificate_provider_application_fixture(
         "self-signed-certificates",
         app=SELF_SIGNED_CERTIFICATES_APP_NAME,
         channel="1/edge",
+        force=True,
     )
     return SELF_SIGNED_CERTIFICATES_APP_NAME
 
@@ -229,15 +230,16 @@ def deploy_iam_bundle_fixture(k8s_juju: jubilant.Juju):
         logger.info("identity-platform is already deployed")
         return
     k8s_juju.deploy(
-        "self-signed-certificates", channel="1/stable", revision=317, trust=True
+        "self-signed-certificates", channel="1/stable", revision=317, trust=True, force=True
     )
-    k8s_juju.deploy("hydra", channel="latest/edge", revision=399, trust=True)
-    k8s_juju.deploy("kratos", channel="latest/edge", revision=567, trust=True)
+    k8s_juju.deploy("hydra", channel="latest/edge", revision=399, trust=True, force=True)
+    k8s_juju.deploy("kratos", channel="latest/edge", revision=567, trust=True, force=True)
     k8s_juju.deploy(
         "identity-platform-login-ui-operator",
         channel="latest/edge",
         revision=200,
         trust=True,
+        force=True,
     )
     k8s_juju.deploy(
         "traefik-k8s",
@@ -245,12 +247,14 @@ def deploy_iam_bundle_fixture(k8s_juju: jubilant.Juju):
         channel="latest/edge",
         revision=270,
         trust=True,
+        force=True,
     )
     k8s_juju.deploy(
         "postgresql-k8s",
         channel="14/edge",
         base="ubuntu@22.04",
         trust=True,
+        force=True,
         config={
             "profile": "testing",
             "plugin_hstore_enable": "true",
@@ -429,6 +433,7 @@ def postgresql_fixture(pytestconfig: pytest.Config, lxd_juju: jubilant.Juju):
         app=POSTGRESQL_APPLICATION,
         channel="16/edge",
         base="ubuntu@24.04",
+        force=True,
     )
     lxd_juju.wait(
         lambda status: jubilant.all_active(status, POSTGRESQL_APPLICATION),

--- a/tests/integration/test_haproxy_ddos.py
+++ b/tests/integration/test_haproxy_ddos.py
@@ -72,9 +72,9 @@ def test_haproxy_ddos_protection_configuration(
         },
     )
     lxd_juju.wait(jubilant.all_active)
-    haproxy_cfg = lxd_juju.cli(
-        "ssh", f"{configured_application_with_tls}/0", "cat /etc/haproxy/haproxy.cfg"
-    )
+    haproxy_cfg = lxd_juju.exec(
+        "cat /etc/haproxy/haproxy.cfg", unit=f"{configured_application_with_tls}/0"
+    ).stdout
 
     assert "table ddos_protection_ip" in haproxy_cfg
     assert "tcp-request connection reject if { sc_conn_rate(0) gt 500 }" in haproxy_cfg


### PR DESCRIPTION
## What this PR does

Replaces all `juju.ssh(unit, cmd)` / `cli("ssh", ...)` calls that read files on units with `juju.exec(cmd, unit=...).stdout`.

## Why

On Juju 4, `juju ssh` fails immediately after deploy with:
```
Permission denied (publickey)
```
This is due to changed SSH key provisioning/propagation timing in Juju 4. `juju exec` routes through the Juju agent and requires no SSH keypair, making it reliable regardless of timing.

## Affected files

- `haproxy-operator/tests/integration/test_haproxy_route.py` — read `haproxy.cfg`
- `haproxy-operator/tests/integration/test_haproxy_route_tcp.py` — 4 reads of `haproxy.cfg`
- `tests/integration/test_haproxy_ddos.py` — was `lxd_juju.cli("ssh", ...)`, now `lxd_juju.exec(...)`
- `haproxy-operator/tests/integration/helper.py` — apache2 access-log grep

## Part of

Juju 4 integration test migration tracked in #577.